### PR TITLE
Render puzzle board as single background texture

### DIFF
--- a/app/src/main/cpp/Renderer.cpp
+++ b/app/src/main/cpp/Renderer.cpp
@@ -2,6 +2,7 @@
 
 #include <game-activity/native_app_glue/android_native_app_glue.h>
 #include <GLES3/gl3.h>
+#include <algorithm>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -280,38 +281,42 @@ void Renderer::createModels() {
         spGemTexture = TextureAsset::createSolidColorTexture(200, 40, 60, 255);
     }
 
+    const auto boardPixelWidth = static_cast<float>(std::max(spBoardTexture->getWidth(), 1));
+    const auto boardPixelHeight = static_cast<float>(std::max(spBoardTexture->getHeight(), 1));
     const float boardHeight = kProjectionHalfHeight * 2.0f;
-    const float cellSize = boardHeight / static_cast<float>(kBoardRows);
-    const float boardWidth = cellSize * static_cast<float>(kBoardColumns);
+    const float boardAspect = boardPixelWidth / boardPixelHeight;
+    const float boardWidth = boardHeight * boardAspect;
+    const float cellWidth = boardWidth / static_cast<float>(kBoardColumns);
+    const float cellHeight = boardHeight / static_cast<float>(kBoardRows);
     const float halfWidth = boardWidth * 0.5f;
     const float halfHeight = boardHeight * 0.5f;
 
     std::vector<Vertex> boardVertices = {
             Vertex(Vector3{halfWidth, halfHeight, -0.1f},
-                   Vector2{static_cast<float>(kBoardColumns), 0.f}),
+                   Vector2{1.f, 0.f}),
             Vertex(Vector3{-halfWidth, halfHeight, -0.1f}, Vector2{0.f, 0.f}),
             Vertex(Vector3{-halfWidth, -halfHeight, -0.1f},
-                   Vector2{0.f, static_cast<float>(kBoardRows)}),
-            Vertex(Vector3{halfWidth, -halfHeight, -0.1f},
-                   Vector2{static_cast<float>(kBoardColumns), static_cast<float>(kBoardRows)})
+                   Vector2{0.f, 1.f}),
+            Vertex(Vector3{halfWidth, -halfHeight, -0.1f}, Vector2{1.f, 1.f})
     };
     std::vector<Index> boardIndices = {0, 1, 2, 0, 2, 3};
     models_.emplace_back(boardVertices, boardIndices, std::move(spBoardTexture));
 
     const float originX = -halfWidth;
     const float originY = halfHeight;
-    const float gemCenterX = originX + cellSize * (static_cast<float>(kTestGemColumn) + 0.5f);
-    const float gemCenterY = originY - cellSize * (static_cast<float>(kTestGemRow) + 0.5f);
-    const float gemHalfSize = (cellSize * kGemVisualScale) * 0.5f;
+    const float gemCenterX = originX + cellWidth * (static_cast<float>(kTestGemColumn) + 0.5f);
+    const float gemCenterY = originY - cellHeight * (static_cast<float>(kTestGemRow) + 0.5f);
+    const float gemHalfWidth = (cellWidth * kGemVisualScale) * 0.5f;
+    const float gemHalfHeight = (cellHeight * kGemVisualScale) * 0.5f;
 
     std::vector<Vertex> gemVertices = {
-            Vertex(Vector3{gemCenterX + gemHalfSize, gemCenterY + gemHalfSize, 0.0f},
+            Vertex(Vector3{gemCenterX + gemHalfWidth, gemCenterY + gemHalfHeight, 0.0f},
                    Vector2{1.f, 0.f}),
-            Vertex(Vector3{gemCenterX - gemHalfSize, gemCenterY + gemHalfSize, 0.0f},
+            Vertex(Vector3{gemCenterX - gemHalfWidth, gemCenterY + gemHalfHeight, 0.0f},
                    Vector2{0.f, 0.f}),
-            Vertex(Vector3{gemCenterX - gemHalfSize, gemCenterY - gemHalfSize, 0.0f},
+            Vertex(Vector3{gemCenterX - gemHalfWidth, gemCenterY - gemHalfHeight, 0.0f},
                    Vector2{0.f, 1.f}),
-            Vertex(Vector3{gemCenterX + gemHalfSize, gemCenterY - gemHalfSize, 0.0f},
+            Vertex(Vector3{gemCenterX + gemHalfWidth, gemCenterY - gemHalfHeight, 0.0f},
                    Vector2{1.f, 1.f})
     };
     std::vector<Index> gemIndices = {0, 1, 2, 0, 2, 3};

--- a/app/src/main/cpp/TextureAsset.cpp
+++ b/app/src/main/cpp/TextureAsset.cpp
@@ -49,9 +49,8 @@ TextureAsset::loadAsset(AAssetManager *assetManager, const std::string &assetPat
     glGenTextures(1, &textureId);
     glBindTexture(GL_TEXTURE_2D, textureId);
 
-    // Repeat textures so the board background can be tiled.
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -77,7 +76,7 @@ TextureAsset::loadAsset(AAssetManager *assetManager, const std::string &assetPat
     AAsset_close(pAndroidRobotPng);
 
     // Create a shared pointer so it can be cleaned up easily/automatically
-    return std::shared_ptr<TextureAsset>(new TextureAsset(textureId));
+    return std::shared_ptr<TextureAsset>(new TextureAsset(textureId, width, height));
 }
 
 std::shared_ptr<TextureAsset> TextureAsset::createSolidColorTexture(
@@ -89,8 +88,8 @@ std::shared_ptr<TextureAsset> TextureAsset::createSolidColorTexture(
     glGenTextures(1, &textureId);
     glBindTexture(GL_TEXTURE_2D, textureId);
 
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
@@ -106,7 +105,7 @@ std::shared_ptr<TextureAsset> TextureAsset::createSolidColorTexture(
             GL_UNSIGNED_BYTE,
             pixel);
 
-    return std::shared_ptr<TextureAsset>(new TextureAsset(textureId));
+    return std::shared_ptr<TextureAsset>(new TextureAsset(textureId, 1, 1));
 }
 
 TextureAsset::~TextureAsset() {

--- a/app/src/main/cpp/TextureAsset.h
+++ b/app/src/main/cpp/TextureAsset.h
@@ -37,10 +37,17 @@ public:
      */
     constexpr GLuint getTextureID() const { return textureID_; }
 
+    constexpr int getWidth() const { return width_; }
+
+    constexpr int getHeight() const { return height_; }
+
 private:
-    inline TextureAsset(GLuint textureId) : textureID_(textureId) {}
+    inline TextureAsset(GLuint textureId, int width, int height)
+            : textureID_(textureId), width_(width), height_(height) {}
 
     GLuint textureID_;
+    int width_;
+    int height_;
 };
 
 #endif //ANDROIDGLINVESTIGATIONS_TEXTUREASSET_H


### PR DESCRIPTION
## Summary
- render the puzzle board asset once as a background quad with non-repeating UVs
- compute board aspect ratio and per-axis cell sizes so gem sprites align to the drawn grid
- expose texture dimensions from TextureAsset and clamp textures to edges to avoid tiling seams

## Testing
- ./gradlew assembleDebug *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e620ded48328942451d56f79714d