### PR TITLE
Implement game state transitions and stabilize board initialization

### DIFF
--- a/app/src/main/cpp/Renderer.h
+++ b/app/src/main/cpp/Renderer.h
@@ -36,7 +36,7 @@ public:
             heroHP_(heroMaxHP_),
             enemyHP_(enemyMaxHP_),
             heroMana_(0),
-            battleOutcome_(BattleOutcome::None) {
+            gameState_(GameState::START) {
         initRenderer();
     }
 
@@ -85,10 +85,11 @@ private:
         std::vector<std::pair<int, int>> cells;
     };
 
-    enum class BattleOutcome {
-        None,
-        Victory,
-        Defeat,
+    enum class GameState {
+        START,
+        PLAYING,
+        VICTORY,
+        DEFEAT,
     };
 
     void ensureBoardInitialized();
@@ -149,7 +150,7 @@ private:
     const int heroMaxHP_ = 100;
     const int enemyMaxHP_ = 100;
     const int heroMaxMana_ = 100;
-    BattleOutcome battleOutcome_;
+    GameState gameState_;
     bool boardGeometryValid_ = false;
     float boardLeft_ = 0.0f;
     float boardRight_ = 0.0f;


### PR DESCRIPTION
## Summary
- introduce a `GameState` enum to manage battle flow and initialize stats when the board is created
- reroll the starting grid until no matches remain so the opening state is stable
- gate match processing on the playing state and render VICTORY/DEFEAT banners when the game ends

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d748abf2888328afd1c7a703b40a69