### PR TITLE
Add global crash handler with email report prompt

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".CrashHandlerApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -11,6 +12,10 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.RouneboundMagic">
+        <activity
+            android:name=".CrashReportActivity"
+            android:exported="false"
+            android:launchMode="singleTop" />
         <activity
             android:name=".IntroActivity"
             android:exported="false" />

--- a/app/src/main/java/com/example/rouneboundmagic/CrashHandlerApplication.kt
+++ b/app/src/main/java/com/example/rouneboundmagic/CrashHandlerApplication.kt
@@ -1,0 +1,35 @@
+package com.example.rouneboundmagic
+
+import android.app.Application
+import android.content.Intent
+import android.util.Log
+
+class CrashHandlerApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            if (!handleUncaughtException(throwable)) {
+                defaultHandler?.uncaughtException(thread, throwable)
+            }
+        }
+    }
+
+    private fun handleUncaughtException(throwable: Throwable): Boolean {
+        val errorMessage = throwable.message?.takeIf { it.isNotBlank() }
+            ?: throwable::class.simpleName
+            ?: "Άγνωστο σφάλμα"
+        val stackTrace = Log.getStackTraceString(throwable)
+
+        val crashIntent = Intent(this, CrashReportActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            putExtra(CrashReportActivity.EXTRA_ERROR_MESSAGE, errorMessage)
+            putExtra(CrashReportActivity.EXTRA_STACK_TRACE, stackTrace)
+        }
+
+        return runCatching {
+            startActivity(crashIntent)
+        }.isSuccess
+    }
+}

--- a/app/src/main/java/com/example/rouneboundmagic/CrashReportActivity.kt
+++ b/app/src/main/java/com/example/rouneboundmagic/CrashReportActivity.kt
@@ -1,0 +1,72 @@
+package com.example.rouneboundmagic
+
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+
+class CrashReportActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        showCrashDialog()
+    }
+
+    private fun showCrashDialog() {
+        val errorMessage = intent.getStringExtra(EXTRA_ERROR_MESSAGE) ?: "Άγνωστο σφάλμα"
+        val stackTrace = intent.getStringExtra(EXTRA_STACK_TRACE) ?: "Δεν βρέθηκε διαθέσιμο stack trace."
+
+        AlertDialog.Builder(this)
+            .setTitle(getString(R.string.app_name))
+            .setMessage("Η εφαρμογή κατέρρευσε. Θέλεις να στείλεις μια αναφορά σφάλματος;")
+            .setCancelable(false)
+            .setPositiveButton("Αποστολή") { _, _ ->
+                sendCrashEmail(errorMessage, stackTrace)
+            }
+            .setNegativeButton("Άκυρο") { _, _ ->
+                Toast.makeText(
+                    this,
+                    "Η αναφορά σφάλματος δεν στάλθηκε.",
+                    Toast.LENGTH_SHORT
+                ).show()
+                finishAffinity()
+            }
+            .show()
+    }
+
+    private fun sendCrashEmail(message: String, stackTrace: String) {
+        val body = buildString {
+            appendLine("Μήνυμα σφάλματος:")
+            appendLine(message)
+            appendLine()
+            appendLine("Stack trace:")
+            appendLine(stackTrace)
+        }
+
+        val emailIntent = Intent(Intent.ACTION_SENDTO).apply {
+            data = Uri.parse("mailto:ioannapergamali@gmail.com")
+            putExtra(Intent.EXTRA_SUBJECT, "App Crash Report")
+            putExtra(Intent.EXTRA_TEXT, body)
+        }
+
+        try {
+            startActivity(Intent.createChooser(emailIntent, "Αποστολή μέσω"))
+        } catch (ex: ActivityNotFoundException) {
+            Toast.makeText(
+                this,
+                "Δεν βρέθηκε εφαρμογή email για αποστολή.",
+                Toast.LENGTH_LONG
+            ).show()
+        } finally {
+            finishAffinity()
+        }
+    }
+
+    companion object {
+        const val EXTRA_ERROR_MESSAGE = "extra_error_message"
+        const val EXTRA_STACK_TRACE = "extra_stack_trace"
+    }
+}


### PR DESCRIPTION
## Summary
- add an Application class that registers a default uncaught exception handler
- introduce a crash report activity that prompts the user to send crash details via email
- register the new application class and crash report activity in the manifest

## Testing
- ./gradlew lint *(fails: SDK location not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dac9c953c0832898e422f562ec40b6