### PR TITLE
Rename rounbound namespace to runeboundmagic

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,14 +4,14 @@ plugins {
 }
 
 android {
-    namespace = "com.example.rouneboundmagic"
+    namespace = "com.example.runeboundmagic"
 
     compileSdk = 35
     ndkVersion = "27.0.12077973"
 
 
     defaultConfig {
-        applicationId = "com.example.rouneboundmagic"
+        applicationId = "com.example.runeboundmagic"
         minSdk = 26
         targetSdk = 35
         versionCode = 1

--- a/app/src/androidTest/java/com/example/runeboundmagic/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/example/runeboundmagic/ExampleInstrumentedTest.kt
@@ -1,4 +1,4 @@
-package com.example.rouneboundmagic
+package com.example.runeboundmagic
 
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -19,6 +19,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("com.example.rouneboundmagic", appContext.packageName)
+        assertEquals("com.example.runeboundmagic", appContext.packageName)
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
             android:exported="false">
             <meta-data
                 android:name="android.app.lib_name"
-                android:value="rouneboundmagic" />
+                android:value="runeboundmagic" />
         </activity>
     </application>
 

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -3,11 +3,11 @@
 
 cmake_minimum_required(VERSION 3.22.1)
 
-project("rouneboundmagic")
+project("runeboundmagic")
 
 # Creates your game shared library. The name must be the same as the
 # one used for loading in your Kotlin/Java or AndroidManifest.txt files.
-add_library(rouneboundmagic SHARED
+add_library(runeboundmagic SHARED
         main.cpp
         AndroidOut.cpp
         Renderer.cpp
@@ -19,7 +19,7 @@ add_library(rouneboundmagic SHARED
 find_package(game-activity REQUIRED CONFIG)
 
 # Configure libraries CMake uses to link your target library.
-target_link_libraries(rouneboundmagic
+target_link_libraries(runeboundmagic
         # The game activity
         game-activity::game-activity
 

--- a/app/src/main/java/com/example/runeboundmagic/CharacterSelectionActivity.kt
+++ b/app/src/main/java/com/example/runeboundmagic/CharacterSelectionActivity.kt
@@ -1,4 +1,4 @@
-package com.example.rouneboundmagic
+package com.example.runeboundmagic
 
 import android.app.Activity
 import android.graphics.Bitmap

--- a/app/src/main/java/com/example/runeboundmagic/CrashHandlerApplication.kt
+++ b/app/src/main/java/com/example/runeboundmagic/CrashHandlerApplication.kt
@@ -1,4 +1,4 @@
-package com.example.rouneboundmagic
+package com.example.runeboundmagic
 
 import android.app.Application
 import android.content.Intent

--- a/app/src/main/java/com/example/runeboundmagic/CrashReportActivity.kt
+++ b/app/src/main/java/com/example/runeboundmagic/CrashReportActivity.kt
@@ -1,4 +1,4 @@
-package com.example.rouneboundmagic
+package com.example.runeboundmagic
 
 import android.content.ActivityNotFoundException
 import android.content.Intent

--- a/app/src/main/java/com/example/runeboundmagic/HeroCarouselAdapter.kt
+++ b/app/src/main/java/com/example/runeboundmagic/HeroCarouselAdapter.kt
@@ -1,4 +1,4 @@
-package com.example.rouneboundmagic
+package com.example.runeboundmagic
 
 import android.graphics.Bitmap
 import android.view.LayoutInflater

--- a/app/src/main/java/com/example/runeboundmagic/HeroOption.kt
+++ b/app/src/main/java/com/example/runeboundmagic/HeroOption.kt
@@ -1,4 +1,4 @@
-package com.example.rouneboundmagic
+package com.example.runeboundmagic
 
 import androidx.annotation.StringRes
 

--- a/app/src/main/java/com/example/runeboundmagic/IntroActivity.kt
+++ b/app/src/main/java/com/example/runeboundmagic/IntroActivity.kt
@@ -1,4 +1,4 @@
-package com.example.rouneboundmagic
+package com.example.runeboundmagic
 
 import android.content.Intent
 import android.graphics.Bitmap

--- a/app/src/main/java/com/example/runeboundmagic/MainActivity.kt
+++ b/app/src/main/java/com/example/runeboundmagic/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.rouneboundmagic
+package com.example.runeboundmagic
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
@@ -25,7 +25,7 @@ class MainActivity : GameActivity() {
         const val EXTRA_SELECTED_HERO = "selected_hero"
 
         init {
-                System.loadLibrary("rouneboundmagic")
+                System.loadLibrary("runeboundmagic")
         }
     }
 

--- a/app/src/main/java/com/example/runeboundmagic/StartGameActivity.kt
+++ b/app/src/main/java/com/example/runeboundmagic/StartGameActivity.kt
@@ -1,4 +1,4 @@
-package com.example.rouneboundmagic
+package com.example.runeboundmagic
 
 import android.content.Intent
 import android.graphics.Bitmap

--- a/app/src/test/java/com/example/runeboundmagic/ExampleUnitTest.kt
+++ b/app/src/test/java/com/example/runeboundmagic/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package com.example.rouneboundmagic
+package com.example.runeboundmagic
 
 import org.junit.Test
 


### PR DESCRIPTION
## Summary
- rename the application namespace, package declarations, and native library identifiers to use `runeboundmagic`
- update associated Android manifest metadata, Gradle configuration, and native build script

## Testing
- `./gradlew test` *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dad92faef08328bc07be57814eb17c