### PR TITLE
Add Jetpack Compose splash screen and navigation setup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,10 @@ android {
     }
     buildFeatures {
         prefab = true
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = libs.versions.composeCompiler.get()
     }
     externalNativeBuild {
         cmake {
@@ -54,7 +58,19 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.games.activity)
     implementation(libs.androidx.viewpager2)
+
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.graphics)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.navigation.compose)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+
+    debugImplementation(libs.androidx.compose.ui.tooling)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
             android:name=".StartGameActivity"
             android:exported="false" />
         <activity
-            android:name=".IntroActivity"
+            android:name=".SplashActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -31,6 +31,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".IntroActivity"
+            android:exported="false" />
         <activity
             android:name=".MainActivity"
             android:exported="false">

--- a/app/src/main/java/com/example/runeboundmagic/SplashActivity.kt
+++ b/app/src/main/java/com/example/runeboundmagic/SplashActivity.kt
@@ -1,0 +1,17 @@
+package com.example.runeboundmagic
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.core.view.WindowCompat
+import com.example.runeboundmagic.ui.RuneboundMagicApp
+
+class SplashActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        setContent {
+            RuneboundMagicApp()
+        }
+    }
+}

--- a/app/src/main/java/com/example/runeboundmagic/ui/AssetPainters.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/AssetPainters.kt
@@ -1,0 +1,30 @@
+package com.example.runeboundmagic.ui
+
+import android.graphics.BitmapFactory
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@Composable
+fun rememberAssetPainter(assetPath: String): Painter {
+    val context = LocalContext.current
+    val painterState = produceState<Painter>(initialValue = ColorPainter(Color.Transparent), context, assetPath) {
+        value = withContext(Dispatchers.IO) {
+            runCatching {
+                context.assets.open(assetPath).use { inputStream ->
+                    BitmapFactory.decodeStream(inputStream)?.asImageBitmap()?.let { bitmap ->
+                        BitmapPainter(bitmap)
+                    }
+                }
+            }.getOrNull() ?: ColorPainter(Color.Transparent)
+        }
+    }
+    return painterState.value
+}

--- a/app/src/main/java/com/example/runeboundmagic/ui/IntroScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/IntroScreen.kt
@@ -1,0 +1,41 @@
+package com.example.runeboundmagic.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun IntroScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.verticalGradient(
+                    colors = listOf(
+                        Color(0xFF000814),
+                        Color(0xFF003049),
+                        Color(0xFF0B3D3B)
+                    )
+                )
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "Καλώς ήρθες στον κόσμο του Runebound Magic!",
+            color = Color.White,
+            fontSize = 24.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 32.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/example/runeboundmagic/ui/RuneboundMagicApp.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/RuneboundMagicApp.kt
@@ -1,0 +1,44 @@
+package com.example.runeboundmagic.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+
+private const val SplashRoute = "splash"
+private const val IntroRoute = "intro"
+
+private val SplashColorScheme = darkColorScheme(
+    primary = Color(0xFF38B6FF),
+    onPrimary = Color.Black,
+    secondary = Color(0xFF00E5A0),
+    onSecondary = Color.Black,
+    background = Color(0xFF000814),
+    onBackground = Color(0xFFE0F2F1)
+)
+
+@Composable
+fun RuneboundMagicApp() {
+    val navController = rememberNavController()
+    MaterialTheme(colorScheme = SplashColorScheme) {
+        NavHost(
+            navController = navController,
+            startDestination = SplashRoute
+        ) {
+            composable(SplashRoute) {
+                SplashScreen(navController = navController)
+            }
+            composable(IntroRoute) {
+                IntroScreen()
+            }
+        }
+    }
+}
+
+internal object Routes {
+    const val Splash = SplashRoute
+    const val Intro = IntroRoute
+}

--- a/app/src/main/java/com/example/runeboundmagic/ui/SplashScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/SplashScreen.kt
@@ -1,0 +1,58 @@
+package com.example.runeboundmagic.ui
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.navigation.NavHostController
+import kotlinx.coroutines.delay
+
+@Composable
+fun SplashScreen(navController: NavHostController) {
+    val alpha = remember { Animatable(0f) }
+
+    LaunchedEffect(Unit) {
+        alpha.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(durationMillis = 2000)
+        )
+        delay(3000)
+        navController.navigate(Routes.Intro) {
+            popUpTo(Routes.Splash) { inclusive = true }
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.verticalGradient(
+                    colors = listOf(
+                        Color(0xFF000000),
+                        Color(0xFF041A2E),
+                        Color(0xFF0B3D3B)
+                    )
+                )
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Image(
+            painter = rememberAssetPainter("logo/RuneboundMagic.png"),
+            contentDescription = "Runebound Magic Logo",
+            modifier = Modifier
+                .fillMaxWidth(0.7f)
+                .alpha(alpha.value)
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,10 @@ appcompat = "1.7.1"
 material = "1.13.0"
 gamesActivity = "1.2.2"
 viewpager2 = "1.1.0"
+composeBom = "2024.10.01"
+composeCompiler = "1.5.15"
+activityCompose = "1.9.3"
+navigationCompose = "2.8.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -19,6 +23,14 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-games-activity = { group = "androidx.games", name = "games-activity", version.ref = "gamesActivity" }
 androidx-viewpager2 = { group = "androidx.viewpager2", name = "viewpager2", version.ref = "viewpager2" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- enable Jetpack Compose build features and dependencies
- introduce a Compose-powered SplashActivity with navigation between splash and intro screens
- implement the animated splash logo fade-in over a magical gradient background sourced from assets

## Testing
- ./gradlew lint *(fails: Android SDK is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db199d21e48328aa1c626c46e5bd3f