### PR TITLE
Fix Compose imports for intro and splash screens

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/ui/IntroScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/IntroScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
@@ -28,6 +29,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.align
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape

--- a/app/src/main/java/com/example/runeboundmagic/ui/SplashScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/SplashScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue


### PR DESCRIPTION
## Summary
- import BoxScope and the BoxScope.align extension in the intro screen so the rune orb helper composes correctly
- import the Compose runtime getValue delegate in the splash screen to allow delegated state access

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db420feb648328b74f1ff093d61bce