### PR TITLE
Add foundation layout dependency to restore Compose align usage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.foundation.layout)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation.compose)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ androidx-compose-material3 = { group = "androidx.compose.material3", name = "mat
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add the Compose foundation layout artifact to the shared version catalog
- depend on the layout module so Modifier.align extensions resolve in the intro screen

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db46d3686c8328a0857c5716d3f8be