### PR TITLE
Fix unresolved align import in IntroScreen

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/ui/IntroScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/IntroScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.align
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape


### PR DESCRIPTION
## Summary
- remove the invalid `align` import from IntroScreen to fix the unresolved reference error

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db485298348328bf17f577e10fcd84