### PR TITLE
Implement hero selection persistence with Room and Firestore

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    id("org.jetbrains.kotlin.kapt")
+    alias(libs.plugins.google.services)
 }
 
 android {
@@ -67,6 +69,14 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.viewmodel.ktx)
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    kapt(libs.androidx.room.compiler)
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.firestore.ktx)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/example/runeboundmagic/CrashHandlerApplication.kt
+++ b/app/src/main/java/com/example/runeboundmagic/CrashHandlerApplication.kt
@@ -3,11 +3,13 @@ package com.example.runeboundmagic
 import android.app.Application
 import android.content.Intent
 import android.util.Log
+import com.google.firebase.FirebaseApp
 
 class CrashHandlerApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        FirebaseApp.initializeApp(this)
         val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
             if (!handleUncaughtException(throwable)) {

--- a/app/src/main/java/com/example/runeboundmagic/HeroChoiceViewModel.kt
+++ b/app/src/main/java/com/example/runeboundmagic/HeroChoiceViewModel.kt
@@ -1,0 +1,53 @@
+package com.example.runeboundmagic
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.runeboundmagic.data.local.HeroChoiceDao
+import com.example.runeboundmagic.data.local.HeroChoiceEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+
+class HeroChoiceViewModel(
+    private val dao: HeroChoiceDao
+) : ViewModel() {
+
+    private val db = Firebase.firestore
+
+    fun saveHeroChoice(playerName: String, heroType: HeroType, heroName: String) {
+        val choice = HeroChoiceEntity(
+            playerName = playerName,
+            heroType = heroType,
+            heroName = heroName,
+            timestamp = System.currentTimeMillis()
+        )
+
+        viewModelScope.launch {
+            dao.insertChoice(choice)
+
+            val data = hashMapOf(
+                "playerName" to playerName,
+                "heroType" to heroType.name,
+                "heroName" to heroName,
+                "timestamp" to choice.timestamp
+            )
+            db.collection("hero_choices").add(data)
+        }
+    }
+
+    fun getLastChoice(): Flow<HeroChoiceEntity?> = dao.observeLastChoice()
+}
+
+class HeroChoiceViewModelFactory(
+    private val dao: HeroChoiceDao
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(HeroChoiceViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return HeroChoiceViewModel(dao) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+    }
+}

--- a/app/src/main/java/com/example/runeboundmagic/HeroType.kt
+++ b/app/src/main/java/com/example/runeboundmagic/HeroType.kt
@@ -1,0 +1,28 @@
+package com.example.runeboundmagic
+
+/**
+ * Αντιπροσωπεύει τον τύπο του ήρωα που επιλέγει ο παίκτης.
+ * Παρέχει βοηθητικούς μετασχηματισμούς για αντιστοίχιση με τα υπάρχοντα [HeroOption]
+ * ώστε να επαναχρησιμοποιούμε τις ίδιες εικόνες και περιγραφές στο lobby.
+ */
+enum class HeroType {
+    WARRIOR,
+    RANGER,
+    PRIESTESS,
+    MAGE,
+    BLACK_MAGE
+}
+
+fun HeroType.toHeroOption(): HeroOption = when (this) {
+    HeroType.WARRIOR -> HeroOption.WARRIOR
+    HeroType.RANGER -> HeroOption.RANGER
+    HeroType.PRIESTESS -> HeroOption.MYSTICAL_PRIESTESS
+    HeroType.MAGE, HeroType.BLACK_MAGE -> HeroOption.MAGE
+}
+
+fun HeroOption.toHeroType(): HeroType = when (this) {
+    HeroOption.WARRIOR -> HeroType.WARRIOR
+    HeroOption.RANGER -> HeroType.RANGER
+    HeroOption.MYSTICAL_PRIESTESS -> HeroType.PRIESTESS
+    HeroOption.MAGE -> HeroType.MAGE
+}

--- a/app/src/main/java/com/example/runeboundmagic/data/local/HeroChoiceDao.kt
+++ b/app/src/main/java/com/example/runeboundmagic/data/local/HeroChoiceDao.kt
@@ -1,0 +1,16 @@
+package com.example.runeboundmagic.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface HeroChoiceDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertChoice(choice: HeroChoiceEntity)
+
+    @Query("SELECT * FROM hero_choices ORDER BY timestamp DESC LIMIT 1")
+    fun observeLastChoice(): Flow<HeroChoiceEntity?>
+}

--- a/app/src/main/java/com/example/runeboundmagic/data/local/HeroChoiceDatabase.kt
+++ b/app/src/main/java/com/example/runeboundmagic/data/local/HeroChoiceDatabase.kt
@@ -1,0 +1,35 @@
+package com.example.runeboundmagic.data.local
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+
+@Database(
+    entities = [HeroChoiceEntity::class],
+    version = 1,
+    exportSchema = false
+)
+@TypeConverters(HeroTypeConverter::class)
+abstract class HeroChoiceDatabase : RoomDatabase() {
+
+    abstract fun heroChoiceDao(): HeroChoiceDao
+
+    companion object {
+        private const val DATABASE_NAME = "hero_choices.db"
+
+        @Volatile
+        private var instance: HeroChoiceDatabase? = null
+
+        fun getInstance(context: Context): HeroChoiceDatabase {
+            return instance ?: synchronized(this) {
+                instance ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    HeroChoiceDatabase::class.java,
+                    DATABASE_NAME
+                ).build().also { instance = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/runeboundmagic/data/local/HeroChoiceEntity.kt
+++ b/app/src/main/java/com/example/runeboundmagic/data/local/HeroChoiceEntity.kt
@@ -1,0 +1,14 @@
+package com.example.runeboundmagic.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.example.runeboundmagic.HeroType
+
+@Entity(tableName = "hero_choices")
+data class HeroChoiceEntity(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val playerName: String,
+    val heroType: HeroType,
+    val heroName: String,
+    val timestamp: Long
+)

--- a/app/src/main/java/com/example/runeboundmagic/data/local/HeroTypeConverter.kt
+++ b/app/src/main/java/com/example/runeboundmagic/data/local/HeroTypeConverter.kt
@@ -1,0 +1,14 @@
+package com.example.runeboundmagic.data.local
+
+import androidx.room.TypeConverter
+import com.example.runeboundmagic.HeroType
+
+class HeroTypeConverter {
+    @TypeConverter
+    fun fromHeroType(heroType: HeroType): String = heroType.name
+
+    @TypeConverter
+    fun toHeroType(value: String): HeroType = runCatching {
+        HeroType.valueOf(value)
+    }.getOrDefault(HeroType.PRIESTESS)
+}

--- a/app/src/main/res/layout/activity_start_game.xml
+++ b/app/src/main/res/layout/activity_start_game.xml
@@ -125,11 +125,39 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/heroNameInputLayout"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="32dp"
+        app:boxBackgroundMode="outline"
+        app:hintEnabled="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/heroCarouselContainer">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/heroNameInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hero_name_hint"
+            android:imeOptions="actionDone"
+            android:inputType="textCapWords"
+            android:maxLines="1"
+            android:textColor="@android:color/white"
+            android:textColorHint="@android:color/white" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
     <TextView
         android:id="@+id/selectedHeroLabel"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="32dp"
+        android:layout_marginTop="16dp"
         android:layout_marginEnd="32dp"
         android:layout_marginBottom="12dp"
         android:gravity="center"
@@ -143,7 +171,8 @@
         app:layout_constraintBottom_toTopOf="@+id/selectHeroButton"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        tools:text="Ήρωας: Mystical Priestess" />
+        app:layout_constraintTop_toBottomOf="@id/heroNameInputLayout"
+        tools:text="Artheon the Warrior" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/backButton"
@@ -163,7 +192,7 @@
         android:layout_width="300dp"
         android:layout_height="120dp"
         android:layout_marginBottom="16dp"
-        android:text="@string/lobby_select_hero"
+        android:text="@string/lobby_confirm_selection"
         android:textAllCaps="false"
         android:textSize="18sp"
         app:cornerRadius="24dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,9 +3,13 @@
     <string name="lobby_select_hero">Επιλογή Ήρωα</string>
     <string name="lobby_select_hero_with_choice">Επιλογή Ήρωα (%1$s)</string>
     <string name="lobby_selected_hero">Ήρωας: %1$s</string>
+    <string name="lobby_selected_custom_hero">%1$s the %2$s</string>
     <string name="lobby_back">Πίσω στην εισαγωγή</string>
     <string name="lobby_start_battle">Έναρξη Μάχης</string>
     <string name="lobby_select_prompt">Επίλεξε έναν ήρωα πριν ξεκινήσεις</string>
+    <string name="lobby_confirm_selection">Επιβεβαίωση Ήρωα</string>
+    <string name="lobby_confirm_selection_with_choice">Επιβεβαίωση (%1$s)</string>
+    <string name="lobby_selection_saved">%1$s the %2$s αποθηκεύτηκε!</string>
     <string name="select_hero">Επίλεξε τον Ήρωά σου</string>
     <string name="hero_warrior">Warrior</string>
     <string name="hero_mage">Mage</string>
@@ -22,4 +26,6 @@
     <string name="hero_cancel_selection">Ακύρωση</string>
     <string name="hero_carousel_previous">Προηγούμενος ήρωας</string>
     <string name="hero_carousel_next">Επόμενος ήρωας</string>
+    <string name="hero_name_hint">Όνομα Ήρωα</string>
+    <string name="error_empty_hero_name">Δώσε ένα όνομα για τον ήρωα</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,11 @@ composeBom = "2024.10.01"
 composeCompiler = "1.5.15"
 activityCompose = "1.9.3"
 navigationCompose = "2.8.3"
+room = "2.6.1"
+lifecycleRuntimeKtx = "2.8.6"
+lifecycleViewmodelKtx = "2.8.6"
+coroutinesAndroid = "1.9.0"
+firebaseBom = "33.6.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -31,9 +36,19 @@ androidx-compose-material3 = { group = "androidx.compose.material3", name = "mat
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycleViewmodelKtx" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutinesAndroid" }
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-firestore-ktx = { group = "com.google.firebase", name = "firebase-firestore-ktx" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+google-services = { id = "com.google.gms.google-services", version = "4.4.2" }
 


### PR DESCRIPTION
## Summary
- add Room entities, DAO, database, and ViewModel to persist hero selections locally and sync them to Firestore
- extend the lobby UI with a hero name input, confirmation workflow, and automatic display of the most recent saved hero
- configure Gradle with lifecycle, Room, coroutine, and Firebase dependencies and initialize Firebase on application startup

## Testing
- ./gradlew :app:assembleDebug *(fails: SDK location not set in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db479925c88328ba1a587d75298cff