### PR TITLE
Fix intro start flow and adjust hero preview layout

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/ui/RuneboundMagicApp.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/RuneboundMagicApp.kt
@@ -1,5 +1,7 @@
 package com.example.runeboundmagic.ui
 
+import android.app.Activity
+import android.content.Intent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
@@ -7,6 +9,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.compose.ui.platform.LocalContext
+import com.example.runeboundmagic.StartGameActivity
 
 private const val SplashRoute = "splash"
 private const val IntroRoute = "intro"
@@ -32,7 +36,13 @@ fun RuneboundMagicApp() {
                 SplashScreen(navController = navController)
             }
             composable(IntroRoute) {
-                IntroScreen()
+                val context = LocalContext.current
+                IntroScreen(
+                    onIntroFinished = {
+                        context.startActivity(Intent(context, StartGameActivity::class.java))
+                        (context as? Activity)?.finish()
+                    }
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- hide the intro logo until the rune reveal and switch the intro typography to the bundled WhisperingSignature font
- ensure the Start Game CTA launches the hero lobby from the compose navigation flow
- resize the hero preview carousel on the final intro scene so cards no longer clip at the screen edges

## Testing
- `./gradlew assembleDebug` *(fails: Android SDK is not configured in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db4b6bd56883289a961ba1126b2d27