### PR TITLE
Fix Compose API updates for intro and lobby screens

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/ui/IntroScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/IntroScreen.kt
@@ -59,7 +59,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
@@ -105,7 +104,7 @@ fun IntroScreen(
     var showStartGameButton by rememberSaveable { mutableStateOf(false) }
     var showRuneLogo by rememberSaveable { mutableStateOf(false) }
 
-    val signatureFont = rememberSignatureFont()
+    val signatureFont = FontFamily.Cursive
 
     val templePainter = rememberAssetPainter("intro/MysticalTempleRuins")
     val magePainter = rememberAssetPainter("characters/black_mage.png")
@@ -763,7 +762,7 @@ private fun FinalClashScene(
         Row(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .padding(horizontal = 24.dp, bottom = 32.dp),
+                .padding(start = 24.dp, end = 24.dp, bottom = 32.dp),
             verticalAlignment = Alignment.Bottom,
             horizontalArrangement = Arrangement.spacedBy(24.dp)
         ) {
@@ -920,7 +919,3 @@ private fun CharacterPortraitCard(
     }
 }
 
-@Composable
-private fun rememberSignatureFont(): FontFamily {
-    return remember { FontFamily(Font(R.font.whisperingsignature)) }
-}

--- a/app/src/main/java/com/example/runeboundmagic/ui/LobbyScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/LobbyScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -181,10 +182,11 @@ fun LobbyScreen(
                             Text(text = stringResource(id = R.string.hero_name_hint))
                         },
                         singleLine = true,
-                        colors = TextFieldDefaults.outlinedTextFieldColors(
-                            unfocusedBorderColor = Color(0xFF2CFF8F),
-                            focusedBorderColor = Color(0xFF38B6FF),
-                            containerColor = Color(0x22000814),
+                        colors = TextFieldDefaults.colors(
+                            unfocusedIndicatorColor = Color(0xFF2CFF8F),
+                            focusedIndicatorColor = Color(0xFF38B6FF),
+                            unfocusedContainerColor = Color(0x22000814),
+                            focusedContainerColor = Color(0x22000814),
                             cursorColor = Color(0xFF38B6FF)
                         )
                     )


### PR DESCRIPTION
## Summary
- αντικαταστήσαμε τη χρήση προσαρμοσμένης γραμματοσειράς στην εισαγωγική οθόνη με την ενσωματωμένη Cursive του Compose
- διορθώσαμε το padding της τελικής σκηνής ώστε να χρησιμοποιεί έγκυρες παραμέτρους
- ενημερώσαμε το LobbyScreen ώστε να χρησιμοποιεί τα νέα TextFieldDefaults.colors και προσθέσαμε το απαραίτητο import background

## Testing
- ./gradlew :app:compileDebugKotlin *(αποτυγχάνει λόγω έλλειψης Android SDK στο περιβάλλον CI)*

------
https://chatgpt.com/codex/tasks/task_e_68db5ac796748328a0050631d13aeb06