### PR TITLE
Implement compose lobby hot zones and hero carousel overlay

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/ui/RuneboundMagicApp.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/RuneboundMagicApp.kt
@@ -1,6 +1,5 @@
 package com.example.runeboundmagic.ui
 
-import android.app.Activity
 import android.content.Intent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
@@ -10,7 +9,9 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.compose.ui.platform.LocalContext
-import com.example.runeboundmagic.StartGameActivity
+import com.example.runeboundmagic.CharacterSelectionActivity
+import com.example.runeboundmagic.HeroOption
+import com.example.runeboundmagic.MainActivity
 
 private const val SplashRoute = "splash"
 private const val IntroRoute = "intro"
@@ -46,8 +47,21 @@ fun RuneboundMagicApp() {
                 )
             }
             composable(LobbyRoute) {
-                LobbyScreen()
-
+                val context = LocalContext.current
+                LobbyScreen(
+                    onBack = { navController.popBackStack() },
+                    onSelectHero = {
+                        context.startActivity(
+                            Intent(context, CharacterSelectionActivity::class.java)
+                        )
+                    },
+                    onStartBattle = { hero: HeroOption, _ ->
+                        val intent = Intent(context, MainActivity::class.java).apply {
+                            putExtra(MainActivity.EXTRA_SELECTED_HERO, hero.name)
+                        }
+                        context.startActivity(intent)
+                    }
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- stretch the lobby background to fill the screen and expose transparent hot zones that match the artwork buttons
- anchor the hero carousel above the stone pedestal while keeping hero naming and persistence tied to the start battle action
- hook lobby callbacks into navigation so back/select hero/start battle trigger the correct flows

## Testing
- ./gradlew lint *(fails: missing Android SDK in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db60709de08328abaa651f75e26d3c