### PR TITLE
Add Firestore-powered Codex experience

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,6 +80,7 @@ dependencies {
     kapt(libs.androidx.room.compiler)
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.firestore.ktx)
+    implementation("io.coil-kt:coil-compose:2.6.0")
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/example/runeboundmagic/codex/CodexModels.kt
+++ b/app/src/main/java/com/example/runeboundmagic/codex/CodexModels.kt
@@ -1,0 +1,96 @@
+package com.example.runeboundmagic.codex
+
+import java.util.Date
+
+/**
+ * Περιγραφικά μοντέλα για το Codex του Runebound. Απλά data classes
+ * ώστε να είναι εύκολα testable και να χαρτογραφούν ευθέως τα έγγραφα Firestore.
+ */
+
+enum class CodexCategory {
+    HERO,
+    CARD,
+    CAMPAIGN,
+    LORE
+}
+
+/**
+ * Βασική οντότητα για κάθε εγγραφή στο Codex.
+ */
+data class CodexEntry(
+    val id: String = "",
+    val category: CodexCategory = CodexCategory.HERO,
+    val name: String = "",
+    val description: String = "",
+    val imageUrl: String = "",
+    val abilities: List<String> = emptyList(),
+    val rarity: String? = null,
+    val role: String? = null,
+    val tags: List<String> = emptyList()
+)
+
+/**
+ * Καταγραφή προόδου παίκτη η οποία αποθηκεύεται στο Firestore.
+ */
+data class PlayerProgress(
+    val id: String = "",
+    val playerId: String = "",
+    val heroId: String = "",
+    val level: Int = 1,
+    val inventory: List<String> = emptyList(),
+    val lastUpdated: Date = Date()
+)
+
+/**
+ * Επίτευγμα που αποθηκεύεται στο cloud.
+ */
+data class Achievement(
+    val id: String = "",
+    val playerId: String = "",
+    val title: String = "",
+    val description: String = "",
+    val unlockedAt: Date = Date()
+)
+
+/**
+ * Bookmark/Favorite εγγραφής Codex για γρήγορη πρόσβαση.
+ */
+data class FavoriteEntry(
+    val entryId: String = "",
+    val playerId: String = "",
+    val createdAt: Date = Date()
+)
+
+/**
+ * Απλή περιγραφή φίλτρων που εφαρμόζονται στο UI.
+ */
+data class CodexFilter(
+    val selectedCategory: CodexCategory? = null,
+    val searchQuery: String = ""
+)
+
+/**
+ * State αντικείμενο για την οθόνη του Codex.
+ */
+data class CodexUiState(
+    val isLoading: Boolean = true,
+    val entries: List<CodexEntry> = emptyList(),
+    val favorites: Set<String> = emptySet(),
+    val filter: CodexFilter = CodexFilter(),
+    val selectedEntry: CodexEntry? = null,
+    val achievements: List<Achievement> = emptyList(),
+    val progress: List<PlayerProgress> = emptyList()
+) {
+    val filteredEntries: List<CodexEntry>
+        get() {
+            val lowerQuery = filter.searchQuery.trim().lowercase()
+            return entries.filter { entry ->
+                val matchesCategory = filter.selectedCategory?.let { entry.category == it } ?: true
+                val matchesQuery = lowerQuery.isBlank() ||
+                    entry.name.lowercase().contains(lowerQuery) ||
+                    entry.description.lowercase().contains(lowerQuery) ||
+                    entry.tags.any { it.lowercase().contains(lowerQuery) }
+                matchesCategory && matchesQuery
+            }
+        }
+}

--- a/app/src/main/java/com/example/runeboundmagic/codex/CodexRepository.kt
+++ b/app/src/main/java/com/example/runeboundmagic/codex/CodexRepository.kt
@@ -1,0 +1,162 @@
+package com.example.runeboundmagic.codex
+
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.QuerySnapshot
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.tasks.await
+import java.util.Date
+import java.util.UUID
+
+interface CodexRepository {
+    fun observeCodex(): Flow<List<CodexEntry>>
+    fun observeFavorites(playerId: String): Flow<Set<String>>
+    fun observeProgress(playerId: String): Flow<List<PlayerProgress>>
+    fun observeAchievements(playerId: String): Flow<List<Achievement>>
+    suspend fun toggleFavorite(playerId: String, entryId: String)
+    suspend fun saveProgress(progress: PlayerProgress)
+    suspend fun unlockAchievement(achievement: Achievement)
+}
+
+class FirestoreCodexRepository(
+    private val firestore: FirebaseFirestore = FirebaseFirestore.getInstance()
+) : CodexRepository {
+
+    private val codexCollection get() = firestore.collection("codex")
+    private fun favoritesCollection(playerId: String) =
+        firestore.collection("players").document(playerId).collection("favorites")
+    private fun progressCollection(playerId: String) =
+        firestore.collection("playersProgress").document(playerId).collection("runs")
+    private fun achievementsCollection(playerId: String) =
+        firestore.collection("achievements").document(playerId).collection("unlocked")
+
+    override fun observeCodex(): Flow<List<CodexEntry>> = callbackFlow {
+        val registration = codexCollection.addSnapshotListener { snapshot, error ->
+            if (error != null) {
+                trySend(emptyList())
+                return@addSnapshotListener
+            }
+            val entries = snapshot?.documents.orEmpty().mapNotNull { document ->
+                val map = document.data.orEmpty()
+                CodexEntry(
+                    id = document.id,
+                    category = CodexCategory.values()
+                        .firstOrNull { it.name.equals(map["category"].toString(), ignoreCase = true) }
+                        ?: CodexCategory.HERO,
+                    name = map["name"]?.toString().orEmpty(),
+                    description = map["description"]?.toString().orEmpty(),
+                    imageUrl = map["imageUrl"]?.toString().orEmpty(),
+                    abilities = (map["abilities"] as? List<*>)?.map { it.toString() } ?: emptyList(),
+                    rarity = map["rarity"]?.toString(),
+                    role = map["role"]?.toString(),
+                    tags = (map["tags"] as? List<*>)?.map { it.toString() } ?: emptyList()
+                )
+            }
+            trySend(entries)
+        }
+        awaitClose { registration.remove() }
+    }
+
+    override fun observeFavorites(playerId: String): Flow<Set<String>> = callbackFlow {
+        val registration = favoritesCollection(playerId).addSnapshotListener { snapshot, error ->
+            if (error != null) {
+                trySend(emptySet())
+                return@addSnapshotListener
+            }
+            val ids = snapshot?.documents.orEmpty().mapNotNull { it.getString("entryId") }.toSet()
+            trySend(ids)
+        }
+        awaitClose { registration.remove() }
+    }
+
+    override fun observeProgress(playerId: String): Flow<List<PlayerProgress>> = callbackFlow {
+        val registration = progressCollection(playerId).addSnapshotListener { snapshot, error ->
+            if (error != null) {
+                trySend(emptyList())
+                return@addSnapshotListener
+            }
+            trySend(snapshot.toProgressList(playerId))
+        }
+        awaitClose { registration.remove() }
+    }
+
+    override fun observeAchievements(playerId: String): Flow<List<Achievement>> = callbackFlow {
+        val registration = achievementsCollection(playerId).addSnapshotListener { snapshot, error ->
+            if (error != null) {
+                trySend(emptyList())
+                return@addSnapshotListener
+            }
+            val achievements = snapshot?.documents.orEmpty().map { document ->
+                Achievement(
+                    id = document.id,
+                    playerId = playerId,
+                    title = document.getString("title").orEmpty(),
+                    description = document.getString("description").orEmpty(),
+                    unlockedAt = document.getDate("unlockedAt") ?: Date()
+                )
+            }
+            trySend(achievements)
+        }
+        awaitClose { registration.remove() }
+    }
+
+    override suspend fun toggleFavorite(playerId: String, entryId: String) {
+        val favorites = favoritesCollection(playerId)
+        val existing = favorites.whereEqualTo("entryId", entryId).get().await()
+        if (existing.isEmpty) {
+            val data = mapOf(
+                "entryId" to entryId,
+                "playerId" to playerId,
+                "createdAt" to Date()
+            )
+            favorites.add(data).await()
+        } else {
+            existing.documents.firstOrNull()?.reference?.delete()?.await()
+        }
+    }
+
+    override suspend fun saveProgress(progress: PlayerProgress) {
+        val documentId = progress.id.ifBlank { UUID.randomUUID().toString() }
+        progressCollection(progress.playerId)
+            .document(documentId)
+            .set(
+                mapOf(
+                    "heroId" to progress.heroId,
+                    "level" to progress.level,
+                    "inventory" to progress.inventory,
+                    "lastUpdated" to progress.lastUpdated
+                )
+            )
+            .await()
+    }
+
+    override suspend fun unlockAchievement(achievement: Achievement) {
+        val documentId = achievement.id.ifBlank { UUID.randomUUID().toString() }
+        achievementsCollection(achievement.playerId)
+            .document(documentId)
+            .set(
+                mapOf(
+                    "title" to achievement.title,
+                    "description" to achievement.description,
+                    "unlockedAt" to achievement.unlockedAt
+                )
+            )
+            .await()
+    }
+}
+
+private fun QuerySnapshot?.toProgressList(playerId: String): List<PlayerProgress> {
+    return this?.documents.orEmpty().map { document ->
+        PlayerProgress(
+            id = document.id,
+            playerId = playerId,
+            heroId = document.getString("heroId").orEmpty(),
+            level = document.getLong("level")?.toInt() ?: 1,
+            inventory = document.get("inventory")?.let { list ->
+                (list as? List<*>)?.map { it.toString() } ?: emptyList()
+            } ?: emptyList(),
+            lastUpdated = document.getDate("lastUpdated") ?: Date()
+        )
+    }
+}

--- a/app/src/main/java/com/example/runeboundmagic/codex/CodexScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/codex/CodexScreen.kt
@@ -1,0 +1,461 @@
+package com.example.runeboundmagic.codex
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.BookmarkBorder
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.example.runeboundmagic.R
+
+@Composable
+fun CodexScreen(
+    modifier: Modifier = Modifier,
+    onBack: () -> Unit,
+    viewModel: CodexViewModel = rememberCodexViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        containerColor = Color(0xFF060B23),
+        topBar = {
+            CodexTopBar(
+                searchQuery = uiState.filter.searchQuery,
+                onSearchQueryChange = viewModel::onSearchQueryChange,
+                onBack = onBack
+            )
+        }
+    ) { padding ->
+        if (uiState.isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(color = Color(0xFF38B6FF))
+            }
+        } else {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+            ) {
+                CodexContent(
+                    uiState = uiState,
+                    onCategorySelected = viewModel::onCategorySelected,
+                    onEntrySelected = viewModel::onEntrySelected,
+                    onToggleFavorite = viewModel::toggleFavorite
+                )
+
+                CodexDetailOverlay(
+                    entry = uiState.selectedEntry,
+                    isFavorite = uiState.selectedEntry?.let { uiState.favorites.contains(it.id) } == true,
+                    onClose = { viewModel.onEntrySelected(null) },
+                    onToggleFavorite = { entry ->
+                        viewModel.toggleFavorite(entry)
+                        if (entry.category == CodexCategory.HERO) {
+                            viewModel.saveProgress(
+                                heroId = entry.id,
+                                level = 1,
+                                inventory = emptyList()
+                            )
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CodexTopBar(
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit,
+    onBack: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color(0xFF060B23))
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onBack) {
+                Icon(
+                    imageVector = Icons.Default.ArrowBack,
+                    contentDescription = null,
+                    tint = Color(0xFF38B6FF)
+                )
+            }
+            Text(
+                text = stringResource(id = R.string.codex_title),
+                style = MaterialTheme.typography.titleLarge.copy(
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold
+                )
+            )
+        }
+
+        TextField(
+            value = searchQuery,
+            onValueChange = onSearchQueryChange,
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = Color(0xFF10163A),
+                unfocusedContainerColor = Color(0xFF10163A),
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+                focusedTextColor = Color.White,
+                unfocusedTextColor = Color.White,
+                focusedLeadingIconColor = Color(0xFF38B6FF),
+                unfocusedLeadingIconColor = Color(0xFF38B6FF)
+            ),
+            placeholder = {
+                Text(
+                    text = stringResource(id = R.string.codex_search_placeholder),
+                    color = Color(0xFF9FA8DA)
+                )
+            },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Default.Search,
+                    contentDescription = null,
+                    tint = Color(0xFF38B6FF)
+                )
+            }
+        )
+    }
+}
+
+@Composable
+private fun CodexContent(
+    uiState: CodexUiState,
+    onCategorySelected: (CodexCategory?) -> Unit,
+    onEntrySelected: (CodexEntry) -> Unit,
+    onToggleFavorite: (CodexEntry) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        CategoryChips(
+            selectedCategory = uiState.filter.selectedCategory,
+            onCategorySelected = onCategorySelected
+        )
+
+        Text(
+            text = stringResource(id = R.string.codex_results, uiState.filteredEntries.size),
+            style = MaterialTheme.typography.bodyMedium.copy(color = Color(0xFF9FA8DA))
+        )
+
+        LazyVerticalGrid(
+            columns = GridCells.Adaptive(160.dp),
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(bottom = 160.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            items(uiState.filteredEntries, key = { it.id }) { entry ->
+                CodexCard(
+                    entry = entry,
+                    isFavorite = uiState.favorites.contains(entry.id),
+                    onClick = { onEntrySelected(entry) },
+                    onFavorite = { onToggleFavorite(entry) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CategoryChips(
+    selectedCategory: CodexCategory?,
+    onCategorySelected: (CodexCategory?) -> Unit
+) {
+    val categories = remember { listOf(null) + CodexCategory.values().toList() }
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        categories.forEach { category ->
+            val label = when (category) {
+                null -> stringResource(id = R.string.codex_all)
+                CodexCategory.HERO -> stringResource(id = R.string.codex_category_heroes)
+                CodexCategory.CARD -> stringResource(id = R.string.codex_category_cards)
+                CodexCategory.CAMPAIGN -> stringResource(id = R.string.codex_category_campaigns)
+                CodexCategory.LORE -> stringResource(id = R.string.codex_category_lore)
+            }
+            val selected = category == selectedCategory
+            AssistChip(
+                onClick = { onCategorySelected(category) },
+                label = {
+                    Text(
+                        text = label,
+                        color = if (selected) Color.Black else Color.White,
+                        fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal
+                    )
+                },
+                colors = AssistChipDefaults.assistChipColors(
+                    containerColor = if (selected) Color(0xFF38B6FF) else Color(0xFF10163A)
+                )
+            )
+        }
+    }
+}
+
+@Composable
+private fun CodexCard(
+    entry: CodexEntry,
+    isFavorite: Boolean,
+    onClick: () -> Unit,
+    onFavorite: () -> Unit
+) {
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFF10163A))
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(160.dp)
+        ) {
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(entry.imageUrl)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = entry.name,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(
+                        Brush.verticalGradient(
+                            colors = listOf(Color.Transparent, Color(0xCC060B23))
+                        )
+                    )
+            )
+            IconButton(
+                onClick = onFavorite,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(8.dp)
+            ) {
+                Icon(
+                    imageVector = if (isFavorite) Icons.Default.Bookmark else Icons.Default.BookmarkBorder,
+                    contentDescription = null,
+                    tint = Color(0xFF38B6FF)
+                )
+            }
+            Column(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(12.dp)
+            ) {
+                Text(
+                    text = entry.name,
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold
+                    )
+                )
+                entry.rarity?.let { rarity ->
+                    Text(
+                        text = rarity,
+                        style = MaterialTheme.typography.labelSmall.copy(color = Color(0xFF9FA8DA))
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CodexDetailOverlay(
+    entry: CodexEntry?,
+    isFavorite: Boolean,
+    onClose: () -> Unit,
+    onToggleFavorite: (CodexEntry) -> Unit
+) {
+    AnimatedVisibility(
+        visible = entry != null,
+        enter = fadeIn(),
+        exit = fadeOut()
+    ) {
+        entry?.let { codexEntry ->
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color(0xCC060B23)),
+                contentAlignment = Alignment.Center
+            ) {
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth(0.9f)
+                        .padding(16.dp),
+                    tonalElevation = 6.dp,
+                    shape = RoundedCornerShape(24.dp),
+                    color = Color(0xFF10163A)
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .padding(24.dp)
+                            .fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = codexEntry.name,
+                                style = MaterialTheme.typography.headlineSmall.copy(
+                                    color = Color.White,
+                                    fontWeight = FontWeight.Bold
+                                )
+                            )
+                            IconButton(onClick = onClose) {
+                                Icon(
+                                    imageVector = Icons.Default.ArrowBack,
+                                    contentDescription = null,
+                                    tint = Color(0xFF38B6FF)
+                                )
+                            }
+                        }
+
+                        AsyncImage(
+                            model = ImageRequest.Builder(LocalContext.current)
+                                .data(codexEntry.imageUrl)
+                                .crossfade(true)
+                                .build(),
+                            contentDescription = codexEntry.name,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(220.dp)
+                                .background(Color(0xFF060B23), RoundedCornerShape(16.dp)),
+                            contentScale = ContentScale.Crop
+                        )
+
+                        Text(
+                            text = codexEntry.description,
+                            style = MaterialTheme.typography.bodyMedium.copy(color = Color(0xFFCFD8FF)),
+                            textAlign = TextAlign.Start
+                        )
+
+                        if (codexEntry.abilities.isNotEmpty()) {
+                            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                Text(
+                                    text = stringResource(id = R.string.codex_abilities),
+                                    style = MaterialTheme.typography.titleSmall.copy(
+                                        color = Color(0xFF38B6FF),
+                                        fontWeight = FontWeight.Bold
+                                    )
+                                )
+                                codexEntry.abilities.forEach { ability ->
+                                    Text(
+                                        text = "• $ability",
+                                        style = MaterialTheme.typography.bodyMedium.copy(color = Color.White)
+                                    )
+                                }
+                            }
+                        }
+
+                        codexEntry.role?.let { role ->
+                            Text(
+                                text = stringResource(id = R.string.codex_role, role),
+                                style = MaterialTheme.typography.bodySmall.copy(color = Color(0xFF9FA8DA))
+                            )
+                        }
+
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = stringResource(
+                                    id = R.string.codex_category_label,
+                                    codexEntry.category.name.lowercase().replaceFirstChar { it.titlecase() }
+                                ),
+                                style = MaterialTheme.typography.labelMedium.copy(color = Color(0xFF9FA8DA))
+                            )
+
+                            IconButton(onClick = { onToggleFavorite(codexEntry) }) {
+                                Icon(
+                                    imageVector = if (isFavorite) Icons.Default.Bookmark else Icons.Default.BookmarkBorder,
+                                    contentDescription = null,
+                                    tint = Color(0xFFFFC107)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun rememberCodexViewModel(): CodexViewModel {
+    val context = LocalContext.current
+    val repository = remember { FirestoreCodexRepository() }
+    val playerId = remember { context.packageName } // Απλό σταθερό id για demo
+    return viewModel(factory = CodexViewModelFactory(repository, playerId))
+}

--- a/app/src/main/java/com/example/runeboundmagic/codex/CodexViewModel.kt
+++ b/app/src/main/java/com/example/runeboundmagic/codex/CodexViewModel.kt
@@ -1,0 +1,127 @@
+package com.example.runeboundmagic.codex
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.Date
+import java.util.UUID
+
+class CodexViewModel(
+    private val repository: CodexRepository,
+    private val playerId: String
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CodexUiState())
+    val uiState: StateFlow<CodexUiState> = _uiState.asStateFlow()
+
+    init {
+        observeCodex()
+        observeFavorites()
+        observeProgress()
+        observeAchievements()
+    }
+
+    private fun observeCodex() {
+        viewModelScope.launch {
+            repository.observeCodex().collect { entries ->
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        entries = entries
+                    )
+                }
+            }
+        }
+    }
+
+    private fun observeFavorites() {
+        viewModelScope.launch {
+            repository.observeFavorites(playerId).collect { favorites ->
+                _uiState.update { it.copy(favorites = favorites) }
+            }
+        }
+    }
+
+    private fun observeProgress() {
+        viewModelScope.launch {
+            repository.observeProgress(playerId).collect { progress ->
+                _uiState.update { it.copy(progress = progress) }
+            }
+        }
+    }
+
+    private fun observeAchievements() {
+        viewModelScope.launch {
+            repository.observeAchievements(playerId).collect { achievements ->
+                _uiState.update { it.copy(achievements = achievements) }
+            }
+        }
+    }
+
+    fun onSearchQueryChange(query: String) {
+        _uiState.update { state ->
+            state.copy(filter = state.filter.copy(searchQuery = query))
+        }
+    }
+
+    fun onCategorySelected(category: CodexCategory?) {
+        _uiState.update { state ->
+            state.copy(filter = state.filter.copy(selectedCategory = category))
+        }
+    }
+
+    fun onEntrySelected(entry: CodexEntry?) {
+        _uiState.update { it.copy(selectedEntry = entry) }
+    }
+
+    fun toggleFavorite(entry: CodexEntry) {
+        viewModelScope.launch {
+            repository.toggleFavorite(playerId, entry.id)
+        }
+    }
+
+    fun saveProgress(heroId: String, level: Int, inventory: List<String>) {
+        viewModelScope.launch {
+            val progress = PlayerProgress(
+                id = UUID.randomUUID().toString(),
+                playerId = playerId,
+                heroId = heroId,
+                level = level,
+                inventory = inventory,
+                lastUpdated = Date()
+            )
+            repository.saveProgress(progress)
+        }
+    }
+
+    fun unlockAchievement(title: String, description: String) {
+        viewModelScope.launch {
+            val achievement = Achievement(
+                id = UUID.randomUUID().toString(),
+                playerId = playerId,
+                title = title,
+                description = description,
+                unlockedAt = Date()
+            )
+            repository.unlockAchievement(achievement)
+        }
+    }
+}
+
+class CodexViewModelFactory(
+    private val repository: CodexRepository,
+    private val playerId: String
+) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(CodexViewModel::class.java)) {
+            return CodexViewModel(repository, playerId) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/com/example/runeboundmagic/ui/LobbyScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/LobbyScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -77,6 +78,7 @@ fun LobbyScreen(
     onBack: () -> Unit,
     onSelectHero: () -> Unit,
     onStartBattle: (HeroOption, String) -> Unit,
+    onOpenCodex: () -> Unit,
     viewModel: HeroChoiceViewModel = lobbyViewModel(),
 ) {
     val context = LocalContext.current
@@ -176,6 +178,17 @@ fun LobbyScreen(
                                 .padding(horizontal = 32.dp),
                             textAlign = TextAlign.Center
                         )
+
+                        OutlinedButton(
+                            onClick = onOpenCodex,
+                            modifier = Modifier.padding(top = 8.dp)
+                        ) {
+                            Text(
+                                text = stringResource(id = R.string.codex_open_button),
+                                color = Color(0xFF38B6FF),
+                                fontWeight = FontWeight.SemiBold
+                            )
+                        }
                     }
                 }
 

--- a/app/src/main/java/com/example/runeboundmagic/ui/RuneboundMagicApp.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/RuneboundMagicApp.kt
@@ -12,10 +12,12 @@ import androidx.compose.ui.platform.LocalContext
 import com.example.runeboundmagic.CharacterSelectionActivity
 import com.example.runeboundmagic.HeroOption
 import com.example.runeboundmagic.MainActivity
+import com.example.runeboundmagic.codex.CodexScreen
 
 private const val SplashRoute = "splash"
 private const val IntroRoute = "intro"
 private const val LobbyRoute = "lobby"
+private const val CodexRoute = "codex"
 
 private val SplashColorScheme = darkColorScheme(
     primary = Color(0xFF38B6FF),
@@ -60,8 +62,14 @@ fun RuneboundMagicApp() {
                             putExtra(MainActivity.EXTRA_SELECTED_HERO, hero.name)
                         }
                         context.startActivity(intent)
+                    },
+                    onOpenCodex = {
+                        navController.navigate(Routes.Codex)
                     }
                 )
+            }
+            composable(CodexRoute) {
+                CodexScreen(onBack = { navController.popBackStack() })
             }
         }
     }
@@ -71,4 +79,5 @@ internal object Routes {
     const val Splash = SplashRoute
     const val Intro = IntroRoute
     const val Lobby = LobbyRoute
+    const val Codex = CodexRoute
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,4 +32,16 @@
     <string name="hero_carousel_next">Επόμενος ήρωας</string>
     <string name="hero_name_hint">Όνομα Ήρωα</string>
     <string name="error_empty_hero_name">Δώσε ένα όνομα για τον ήρωα</string>
+    <string name="codex_title">Runebound Codex</string>
+    <string name="codex_search_placeholder">Αναζήτηση σε ήρωες, κάρτες, lore…</string>
+    <string name="codex_all">Όλα</string>
+    <string name="codex_category_heroes">Ήρωες</string>
+    <string name="codex_category_cards">Κάρτες</string>
+    <string name="codex_category_campaigns">Περιπέτειες</string>
+    <string name="codex_category_lore">Ιστορίες</string>
+    <string name="codex_results">%1$d εγγραφές</string>
+    <string name="codex_abilities">Ικανότητες</string>
+    <string name="codex_role">Ρόλος: %1$s</string>
+    <string name="codex_category_label">Κατηγορία: %1$s</string>
+    <string name="codex_open_button">Άνοιγμα Codex</string>
 </resources>


### PR DESCRIPTION
## Summary
- προστέθηκαν data models και repository για το Codex με υποστήριξη Firestore, progress και achievements
- δημιουργήθηκε νέα οθόνη Codex σε Jetpack Compose με αναζήτηση, φίλτρα, favorites και λεπτομέρειες
- συνδέθηκε το Codex με το Lobby, προστέθηκαν νέες μεταβάσεις πλοήγησης και εξάρτηση coil για φόρτωση εικόνων

## Testing
- ./gradlew :app:assembleDebug *(αποτυχία: λείπει Android SDK στο περιβάλλον δοκιμών)*

------
https://chatgpt.com/codex/tasks/task_e_68db68096b4c83288211aa45f31f4d16