### PR TITLE
Add Compose material icons dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.foundation.layout)
+    implementation("androidx.compose.material:material-icons-extended")
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.lifecycle.runtime.ktx)


### PR DESCRIPTION
## Summary
- add the Compose Material icons extended artifact so Bookmark icons resolve

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db69b537ac83288378a03104b72b3e