### PR TITLE
Revamp lobby carousel with media-aware state

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.firestore.ktx)
     implementation("io.coil-kt:coil-compose:2.6.0")
+    implementation("androidx.media3:media3-exoplayer:1.4.1")
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/example/runeboundmagic/MediaState.kt
+++ b/app/src/main/java/com/example/runeboundmagic/MediaState.kt
@@ -1,0 +1,36 @@
+package com.example.runeboundmagic
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+
+/**
+ * Απλή κατάσταση αναπαραγωγής για να γνωρίζουμε αν παίζει το τελικό clip (a4).
+ */
+class MediaState {
+    var isA4Playing by mutableStateOf(false)
+        internal set
+}
+
+private val FinaleMediaIds = setOf("a4.mp3", "a4.mp4", "a4")
+
+private fun isFinaleMedia(mediaId: String?): Boolean = mediaId != null && mediaId in FinaleMediaIds
+
+/**
+ * Παρακολουθεί το [Player] και ενημερώνει την [MediaState] μόνο όταν παίζει το a4 clip.
+ */
+fun Player.attachA4Observer(mediaState: MediaState) {
+    addListener(object : Player.Listener {
+        override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+            val isCurrentA4 = isFinaleMedia(mediaItem?.mediaId)
+            mediaState.isA4Playing = isCurrentA4 && this@attachA4Observer.isPlaying
+        }
+
+        override fun onIsPlayingChanged(isPlaying: Boolean) {
+            val isCurrentA4 = isFinaleMedia(currentMediaItem?.mediaId)
+            mediaState.isA4Playing = isPlaying && isCurrentA4
+        }
+    })
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="lobby_confirm_selection_with_choice">Επιβεβαίωση (%1$s)</string>
     <string name="lobby_selection_saved">%1$s – %2$s αποθηκεύτηκε!</string>
     <string name="lobby_title">Runebound Lobby</string>
-    <string name="lobby_subtitle">Διάλεξε τον ήρωα σου και ξεκίνα την περιπέτεια.</string>
+    <string name="lobby_subtitle">Διάλεξε τον ήρωά σου και ξεκίνα.</string>
     <string name="lobby_last_choice">Τελευταία επιλογή: %1$s – %2$s</string>
     <string name="lobby_last_saved_time">Αποθηκεύτηκε: %1$s</string>
     <string name="select_hero">Επίλεξε τον Ήρωά σου</string>


### PR DESCRIPTION
## Summary
- ανασχεδίαση της οθόνης lobby με πιο απλή σκηνογραφία, κουμπιά υλικού και συμπαγή κάρτα ήρωα
- προσθήκη MediaState και παρατηρητή ExoPlayer ώστε το καρουζέλ να αυτοματοποιείται όταν παίζει το τελικό clip a4
- ενημέρωση εξαρτήσεων (Media3 ExoPlayer) και των κειμένων για πιο σύντομο υπότιτλο

## Testing
- ./gradlew lint *(αποτυχία: λείπει Android SDK στο περιβάλλον του CI)*

------
https://chatgpt.com/codex/tasks/task_e_68db6d628978832883bf307874e5318e