### PR TITLE
Add background soundtrack controller for intro and lobby

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/SplashActivity.kt
+++ b/app/src/main/java/com/example/runeboundmagic/SplashActivity.kt
@@ -1,17 +1,23 @@
 package com.example.runeboundmagic
 
+import android.media.AudioManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.core.view.WindowCompat
+import com.example.runeboundmagic.audio.BackgroundMusicController
 import com.example.runeboundmagic.ui.RuneboundMagicApp
 
 class SplashActivity : ComponentActivity() {
+    private val backgroundMusicController by lazy { BackgroundMusicController(this) }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        volumeControlStream = AudioManager.STREAM_MUSIC
+        lifecycle.addObserver(backgroundMusicController)
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
-            RuneboundMagicApp()
+            RuneboundMagicApp(backgroundMusicController)
         }
     }
 }

--- a/app/src/main/java/com/example/runeboundmagic/audio/BackgroundMusicController.kt
+++ b/app/src/main/java/com/example/runeboundmagic/audio/BackgroundMusicController.kt
@@ -1,0 +1,68 @@
+package com.example.runeboundmagic.audio
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.MediaPlayer
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.example.runeboundmagic.R
+
+class BackgroundMusicController(private val context: Context) : DefaultLifecycleObserver {
+    private var mediaPlayer: MediaPlayer? = null
+    private var shouldResumeOnStart = false
+
+    fun startOrResume() {
+        shouldResumeOnStart = true
+        val player = ensurePlayer()
+        if (!player.isPlaying) {
+            player.start()
+        }
+    }
+
+    fun stop() {
+        shouldResumeOnStart = false
+        mediaPlayer?.let { player ->
+            if (player.isPlaying) {
+                player.stop()
+            }
+            player.release()
+        }
+        mediaPlayer = null
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        if (shouldResumeOnStart) {
+            val player = ensurePlayer()
+            if (!player.isPlaying) {
+                player.start()
+            }
+        }
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        mediaPlayer?.takeIf { it.isPlaying }?.pause()
+    }
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        stop()
+    }
+
+    private fun ensurePlayer(): MediaPlayer {
+        mediaPlayer?.let { return it }
+        val assetDescriptor = context.resources.openRawResourceFd(R.raw.soundtrack)
+        val player = MediaPlayer()
+        player.setAudioAttributes(
+            AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_GAME)
+                .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                .build()
+        )
+        player.setDataSource(assetDescriptor.fileDescriptor, assetDescriptor.startOffset, assetDescriptor.length)
+        assetDescriptor.close()
+        player.isLooping = true
+        player.prepare()
+        player.setVolume(1f, 1f)
+        mediaPlayer = player
+        return player
+    }
+}

--- a/app/src/main/java/com/example/runeboundmagic/ui/IntroScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/IntroScreen.kt
@@ -78,9 +78,11 @@ import kotlinx.coroutines.delay
 @Composable
 fun IntroScreen(
     modifier: Modifier = Modifier,
+    onIntroShown: () -> Unit = {},
     onIntroFinished: () -> Unit = {}
 ) {
     val context = LocalContext.current
+    LaunchedEffect(Unit) { onIntroShown() }
     val scenes = remember {
         listOf(
             IntroSceneDefinition(

--- a/app/src/main/java/com/example/runeboundmagic/ui/LobbyScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/LobbyScreen.kt
@@ -84,12 +84,15 @@ fun LobbyScreen(
     onSelectHero: () -> Unit,
     onStartBattle: (HeroOption, String) -> Unit,
     onOpenCodex: () -> Unit,
+    onLobbyShown: () -> Unit = {},
     isA4Playing: Boolean = false,
     viewModel: HeroChoiceViewModel = lobbyViewModel(),
 ) {
     val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
+
+    LaunchedEffect(Unit) { onLobbyShown() }
 
     val heroes = remember { HeroOption.values().toList() }
     var selectedHero by rememberSaveable { mutableStateOf(heroes.first()) }

--- a/app/src/main/java/com/example/runeboundmagic/ui/RuneboundMagicApp.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/RuneboundMagicApp.kt
@@ -1,8 +1,8 @@
 package com.example.runeboundmagic.ui
 
 import android.content.Intent
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.navigation.compose.NavHost
@@ -12,6 +12,7 @@ import androidx.compose.ui.platform.LocalContext
 import com.example.runeboundmagic.CharacterSelectionActivity
 import com.example.runeboundmagic.HeroOption
 import com.example.runeboundmagic.MainActivity
+import com.example.runeboundmagic.audio.BackgroundMusicController
 import com.example.runeboundmagic.codex.CodexScreen
 
 private const val SplashRoute = "splash"
@@ -29,7 +30,7 @@ private val SplashColorScheme = darkColorScheme(
 )
 
 @Composable
-fun RuneboundMagicApp() {
+fun RuneboundMagicApp(musicController: BackgroundMusicController) {
     val navController = rememberNavController()
     MaterialTheme(colorScheme = SplashColorScheme) {
         NavHost(
@@ -41,6 +42,7 @@ fun RuneboundMagicApp() {
             }
             composable(IntroRoute) {
                 IntroScreen(
+                    onIntroShown = { musicController.startOrResume() },
                     onIntroFinished = {
                         navController.navigate(Routes.Lobby) {
                             popUpTo(Routes.Splash) { inclusive = true }
@@ -58,6 +60,7 @@ fun RuneboundMagicApp() {
                         )
                     },
                     onStartBattle = { hero: HeroOption, _ ->
+                        musicController.stop()
                         val intent = Intent(context, MainActivity::class.java).apply {
                             putExtra(MainActivity.EXTRA_SELECTED_HERO, hero.name)
                         }
@@ -65,7 +68,8 @@ fun RuneboundMagicApp() {
                     },
                     onOpenCodex = {
                         navController.navigate(Routes.Codex)
-                    }
+                    },
+                    onLobbyShown = { musicController.startOrResume() }
                 )
             }
             composable(CodexRoute) {


### PR DESCRIPTION
## Summary
- create an activity-scoped BackgroundMusicController that loops the soundtrack and respects the lifecycle
- wire SplashActivity to own the controller and share it with the intro and lobby composables
- trigger playback when intro or lobby screens appear and stop the track when gameplay starts

## Testing
- ./gradlew lint *(fails: SDK location not found in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68dba61089cc832885ef19fd693ba93f