### PR TITLE
Add GridLayout dependency for character selection

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.games.activity)
     implementation(libs.androidx.viewpager2)
+    implementation("androidx.gridlayout:gridlayout:1.0.0")
 
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.ui)


### PR DESCRIPTION
## Summary
- add the AndroidX GridLayout dependency required by the character selection screen layout

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb794d0608328b9d44a7640241f6f