### PR TITLE
Redesign lobby screen with tracked interactions

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/HeroChoiceViewModel.kt
+++ b/app/src/main/java/com/example/runeboundmagic/HeroChoiceViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.example.runeboundmagic.data.local.HeroChoiceDao
 import com.example.runeboundmagic.data.local.HeroChoiceEntity
+import com.example.runeboundmagic.data.local.LobbyInteractionEntity
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import com.google.firebase.firestore.ktx.firestore
@@ -38,6 +39,34 @@ class HeroChoiceViewModel(
     }
 
     fun getLastChoice(): Flow<HeroChoiceEntity?> = dao.observeLastChoice()
+
+    fun logInteraction(
+        event: LobbyInteractionEvent,
+        heroType: HeroType,
+        heroDisplayName: String,
+        heroNameInput: String
+    ) {
+        val interaction = LobbyInteractionEntity(
+            eventType = event.name,
+            heroType = heroType,
+            heroDisplayName = heroDisplayName,
+            heroNameInput = heroNameInput,
+            timestamp = System.currentTimeMillis()
+        )
+
+        viewModelScope.launch {
+            dao.insertInteraction(interaction)
+
+            val data = hashMapOf(
+                "eventType" to event.name,
+                "heroType" to heroType.name,
+                "heroDisplayName" to heroDisplayName,
+                "heroNameInput" to heroNameInput,
+                "timestamp" to interaction.timestamp
+            )
+            db.collection("lobby_interactions").add(data)
+        }
+    }
 }
 
 class HeroChoiceViewModelFactory(

--- a/app/src/main/java/com/example/runeboundmagic/LobbyInteractionEvent.kt
+++ b/app/src/main/java/com/example/runeboundmagic/LobbyInteractionEvent.kt
@@ -1,0 +1,10 @@
+package com.example.runeboundmagic
+
+enum class LobbyInteractionEvent {
+    HERO_SELECTED,
+    HERO_NAME_CHANGED,
+    SELECT_HERO_CLICKED,
+    BACK_CLICKED,
+    START_BATTLE_CLICKED,
+    CODEX_CLICKED
+}

--- a/app/src/main/java/com/example/runeboundmagic/data/local/HeroChoiceDao.kt
+++ b/app/src/main/java/com/example/runeboundmagic/data/local/HeroChoiceDao.kt
@@ -13,4 +13,7 @@ interface HeroChoiceDao {
 
     @Query("SELECT * FROM hero_choices ORDER BY timestamp DESC LIMIT 1")
     fun observeLastChoice(): Flow<HeroChoiceEntity?>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertInteraction(interaction: LobbyInteractionEntity)
 }

--- a/app/src/main/java/com/example/runeboundmagic/data/local/HeroChoiceDatabase.kt
+++ b/app/src/main/java/com/example/runeboundmagic/data/local/HeroChoiceDatabase.kt
@@ -7,8 +7,8 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 
 @Database(
-    entities = [HeroChoiceEntity::class],
-    version = 1,
+    entities = [HeroChoiceEntity::class, LobbyInteractionEntity::class],
+    version = 2,
     exportSchema = false
 )
 @TypeConverters(HeroTypeConverter::class)
@@ -28,7 +28,10 @@ abstract class HeroChoiceDatabase : RoomDatabase() {
                     context.applicationContext,
                     HeroChoiceDatabase::class.java,
                     DATABASE_NAME
-                ).build().also { instance = it }
+                )
+                    .fallbackToDestructiveMigration()
+                    .build()
+                    .also { instance = it }
             }
         }
     }

--- a/app/src/main/java/com/example/runeboundmagic/data/local/LobbyInteractionEntity.kt
+++ b/app/src/main/java/com/example/runeboundmagic/data/local/LobbyInteractionEntity.kt
@@ -1,0 +1,15 @@
+package com.example.runeboundmagic.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.example.runeboundmagic.HeroType
+
+@Entity(tableName = "lobby_interactions")
+data class LobbyInteractionEntity(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val eventType: String,
+    val heroType: HeroType,
+    val heroDisplayName: String,
+    val heroNameInput: String,
+    val timestamp: Long
+)


### PR DESCRIPTION
## Summary
- restyled the lobby to use the Game_Lobby background with invisible hit targets over the native artwork buttons
- placed the hero carousel, detail texts, and name field above the buttons while logging selections and name edits to Room and Firestore
- introduced persistent lobby interaction entities with a fallback migration so clicks are stored locally and remotely

## Testing
- ./gradlew lint *(fails: requires Android SDK path in local.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68dbbf32493c83289a1dfccaff573d91