### PR TITLE
Fix missing width import in LobbyScreen

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/ui/LobbyScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/LobbyScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size


### PR DESCRIPTION
## Summary
- add the missing width modifier import used by HeroCarouselCard

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbc63be0148328b4bb39687b4aa6fa