### PR TITLE
Fix missing Column closure in lobby screen

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/ui/LobbyScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/LobbyScreen.kt
@@ -266,7 +266,7 @@ fun LobbyScreen(
                 )
 
                 Spacer(modifier = Modifier.height(12.dp))
-
+            }
 
             val selectionSignature = remember(selectedHero, playerName) {
                 playerName.trim() to selectedHero.name


### PR DESCRIPTION
## Summary
- close the hero selection Column so derived state and helpers compile correctly

## Testing
- ./gradlew :app:kaptGenerateStubsDebugKotlin --console=plain --quiet *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfa6b8658832894d4d39a10e5702f