### PR TITLE
Adjust rune cluster spacing in final intro scene

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/ui/IntroScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/IntroScreen.kt
@@ -827,7 +827,9 @@ private fun FinalClashScene(
                 earthRunePainter = earthRunePainter,
                 scale = runeScale,
                 alpha = runeAlpha,
-                modifier = Modifier.padding(top = 40.dp, bottom = 48.dp)
+                modifier = Modifier
+                    .padding(top = 40.dp, bottom = 48.dp)
+                    .offset(y = (-32).dp)
             )
             Row(
                 modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
## Summary
- raise the rune cluster in the final intro scene to avoid overlapping the hero cards by applying an upward offset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc1cb658a483288359ca936485f23a