### PR TITLE
Fix Compose padding and pager compilation issues

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/ui/IntroScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/IntroScreen.kt
@@ -817,7 +817,7 @@ private fun FinalClashScene(
             modifier = Modifier
                 .fillMaxSize()
                 .align(Alignment.Center)
-                .padding(horizontal = 24.dp, top = 160.dp, bottom = 120.dp),
+                .padding(start = 24.dp, end = 24.dp, top = 160.dp, bottom = 120.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             RuneCluster(

--- a/app/src/main/java/com/example/runeboundmagic/ui/LobbyScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/LobbyScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -63,7 +64,6 @@ import com.example.runeboundmagic.toHeroOption
 import com.example.runeboundmagic.toHeroType
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.snapshotFlow
 import kotlinx.coroutines.launch
 
 @Composable
@@ -476,7 +476,6 @@ private fun HeroCarousel(
     HorizontalPager(
         state = pagerState,
         pageSize = PageSize.Fixed(180.dp),
-        beyondBoundsPageCount = 1,
         contentPadding = PaddingValues(horizontal = 64.dp),
         pageSpacing = 20.dp,
         modifier = modifier


### PR DESCRIPTION
## Summary
- adjust intro screen column padding to use explicit start/end values
- switch lobby snapshotFlow import to the compose runtime extension and remove the unsupported pager parameter

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not configured in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1c504a34832893f68f7462258143