### PR TITLE
Add hero inventory model with hero card slot for Sora

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/codex/CodexModels.kt
+++ b/app/src/main/java/com/example/runeboundmagic/codex/CodexModels.kt
@@ -30,6 +30,25 @@ data class CodexEntry(
 )
 
 /**
+ * Αναπαριστά την κάρτα ήρωα που συνδέεται με το inventory.
+ */
+data class HeroCardSlot(
+    val id: String = "",
+    val name: String = "",
+    val lore: String = ""
+)
+
+/**
+ * Inventory ενός ήρωα με προαιρετική κάρτα και λίστα αντικειμένων.
+ */
+data class HeroInventory(
+    val heroCard: HeroCardSlot? = null,
+    val equipment: List<String> = emptyList()
+) {
+    val hasHeroCard: Boolean get() = heroCard != null
+}
+
+/**
  * Καταγραφή προόδου παίκτη η οποία αποθηκεύεται στο Firestore.
  */
 data class PlayerProgress(
@@ -37,7 +56,7 @@ data class PlayerProgress(
     val playerId: String = "",
     val heroId: String = "",
     val level: Int = 1,
-    val inventory: List<String> = emptyList(),
+    val inventory: HeroInventory = HeroInventory(),
     val lastUpdated: Date = Date()
 )
 

--- a/app/src/main/java/com/example/runeboundmagic/codex/CodexScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/codex/CodexScreen.kt
@@ -54,6 +54,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.example.runeboundmagic.R
+import java.util.Locale
 
 @Composable
 fun CodexScreen(
@@ -106,7 +107,7 @@ fun CodexScreen(
                             viewModel.saveProgress(
                                 heroId = entry.id,
                                 level = 1,
-                                inventory = emptyList()
+                                inventory = buildHeroInventory(entry)
                             )
                         }
                     }
@@ -114,6 +115,29 @@ fun CodexScreen(
             }
         }
     }
+}
+
+private fun buildHeroInventory(entry: CodexEntry): HeroInventory {
+    val cleanedId = entry.id.ifBlank {
+        entry.name.lowercase(Locale.ROOT).replace("\s+".toRegex(), "_")
+    }
+    val idForLore = entry.id.ifBlank { entry.name }
+    val heroCardLore = when (idForLore.lowercase(Locale.ROOT)) {
+        "sora" -> "Η Sora είναι ανιχνεύτρια των ουρανών που συνδυάζει τεχνολογία και αρχαία ρούνια. Η κάρτα της υπενθυμίζει στον παίκτη ότι κάθε αποστολή απαιτεί στρατηγική, ευελιξία και μια εφεδρική επιλογή για την ίδια την κάρτα του ήρωα."
+        else -> entry.description.ifBlank {
+            "Η κάρτα του ήρωα λειτουργεί ως γρήγορη αναφορά για τις ικανότητες και τα σημεία ισχύος του."
+        }
+    }
+    val heroCardName = entry.name.ifBlank { "Άγνωστος Ήρωας" }
+    val heroCardSlot = HeroCardSlot(
+        id = "${cleanedId}_hero_card",
+        name = "Κάρτα Ήρωα $heroCardName",
+        lore = heroCardLore
+    )
+    return HeroInventory(
+        heroCard = heroCardSlot,
+        equipment = emptyList()
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/example/runeboundmagic/codex/CodexViewModel.kt
+++ b/app/src/main/java/com/example/runeboundmagic/codex/CodexViewModel.kt
@@ -85,7 +85,7 @@ class CodexViewModel(
         }
     }
 
-    fun saveProgress(heroId: String, level: Int, inventory: List<String>) {
+    fun saveProgress(heroId: String, level: Int, inventory: HeroInventory) {
         viewModelScope.launch {
             val progress = PlayerProgress(
                 id = UUID.randomUUID().toString(),


### PR DESCRIPTION
## Summary
- introduce dedicated HeroInventory and HeroCardSlot data models so hero progress keeps a slot for the hero card
- persist the structured inventory to and from Firestore instead of a flat list
- create inventories from the Codex with Sora-specific περιγραφή για την κάρτα του ήρωα

## Testing
- not run (Android SDK is not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc1d3ac4b483289074ac081439ea1f