### PR TITLE
Fix Codex hero ID regex escaping

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/codex/CodexScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/codex/CodexScreen.kt
@@ -119,7 +119,7 @@ fun CodexScreen(
 
 private fun buildHeroInventory(entry: CodexEntry): HeroInventory {
     val cleanedId = entry.id.ifBlank {
-        entry.name.lowercase(Locale.ROOT).replace("\s+".toRegex(), "_")
+        entry.name.lowercase(Locale.ROOT).replace("""\s+""".toRegex(), "_")
     }
     val idForLore = entry.id.ifBlank { entry.name }
     val heroCardLore = when (idForLore.lowercase(Locale.ROOT)) {


### PR DESCRIPTION
## Summary
- use a raw regular expression string when normalizing hero identifiers to avoid Kotlin escape issues

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc250c69448328b63e15f4c51dde3a