### PR TITLE
Add core hero, lobby, and inventory models

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/heroes/Hero.kt
+++ b/app/src/main/java/com/example/runeboundmagic/heroes/Hero.kt
@@ -1,0 +1,32 @@
+package com.example.runeboundmagic.heroes
+
+import com.example.runeboundmagic.inventory.Inventory
+
+/**
+ * Μοντέλο για έναν διαθέσιμο ήρωα που εμφανίζεται στο lobby.
+ */
+data class Hero(
+    val id: String,
+    val name: String,
+    val level: Int,
+    val classType: HeroClass,
+    val cardImage: String
+) {
+    /**
+     * Γρήγορη δημιουργία προσωπικού inventory με προεπιλεγμένη χωρητικότητα.
+     */
+    fun createInventory(
+        inventoryId: String = "${'$'}id-inventory",
+        gold: Int = 0,
+        capacity: Int = DEFAULT_CAPACITY
+    ): Inventory = Inventory(
+        id = inventoryId,
+        heroId = id,
+        gold = gold,
+        capacity = capacity
+    )
+
+    companion object {
+        const val DEFAULT_CAPACITY = 30
+    }
+}

--- a/app/src/main/java/com/example/runeboundmagic/heroes/HeroClass.kt
+++ b/app/src/main/java/com/example/runeboundmagic/heroes/HeroClass.kt
@@ -1,0 +1,11 @@
+package com.example.runeboundmagic.heroes
+
+/**
+ * Κλάσεις ηρώων με απλό περιγραφικό κείμενο για το lobby.
+ */
+enum class HeroClass(val description: String) {
+    WARRIOR("Δυνατός μαχητής σώμα με σώμα."),
+    MAGE("Κυρίαρχος των ρούνων και της μαγείας."),
+    RANGER("Ευκίνητος τοξότης με κρυφές τακτικές."),
+    PRIESTESS("Θεραπεύτρια και σύμμαχος του φωτός.");
+}

--- a/app/src/main/java/com/example/runeboundmagic/inventory/Inventory.kt
+++ b/app/src/main/java/com/example/runeboundmagic/inventory/Inventory.kt
@@ -1,0 +1,26 @@
+package com.example.runeboundmagic.inventory
+
+/**
+ * Απλό inventory που αντιστοιχίζεται σε συγκεκριμένο ήρωα.
+ */
+class Inventory(
+    val id: String,
+    val heroId: String,
+    var gold: Int,
+    val capacity: Int,
+    private val items: MutableList<Item> = mutableListOf()
+) {
+
+    fun addItem(item: Item): Boolean {
+        if (items.size >= capacity) return false
+        items += item
+        return true
+    }
+
+    fun removeItem(itemId: String): Boolean = items.removeIf { it.id == itemId }
+
+    fun getItemsByCategory(category: ItemCategory): List<Item> =
+        items.filter { it.category == category }
+
+    fun getAllItems(): List<Item> = items.toList()
+}

--- a/app/src/main/java/com/example/runeboundmagic/inventory/Item.kt
+++ b/app/src/main/java/com/example/runeboundmagic/inventory/Item.kt
@@ -1,0 +1,23 @@
+package com.example.runeboundmagic.inventory
+
+/**
+ * Βασική περιγραφή αντικειμένου που μπορεί να αποθηκευτεί σε inventory.
+ */
+data class Item(
+    val id: String,
+    val name: String,
+    val description: String,
+    val icon: String,
+    val rarity: Rarity,
+    val category: ItemCategory
+)
+
+/**
+ * Βαθμίδες σπανιότητας για εύκολη ομαδοποίηση αντικειμένων.
+ */
+enum class Rarity {
+    COMMON,
+    RARE,
+    EPIC,
+    LEGENDARY
+}

--- a/app/src/main/java/com/example/runeboundmagic/inventory/ItemCategory.kt
+++ b/app/src/main/java/com/example/runeboundmagic/inventory/ItemCategory.kt
@@ -1,0 +1,17 @@
+package com.example.runeboundmagic.inventory
+
+/**
+ * Όλες οι κατηγορίες αντικειμένων που υποστηρίζει το inventory.
+ */
+enum class ItemCategory {
+    WEAPON,
+    ARMOR,
+    SHIELD,
+    ACCESSORY,
+    CONSUMABLE,
+    SPELL_SCROLL,
+    RUNE_GEM,
+    MATERIAL,
+    QUEST_ITEM,
+    CURRENCY
+}

--- a/app/src/main/java/com/example/runeboundmagic/lobby/HeroCard.kt
+++ b/app/src/main/java/com/example/runeboundmagic/lobby/HeroCard.kt
@@ -1,0 +1,23 @@
+package com.example.runeboundmagic.lobby
+
+import com.example.runeboundmagic.heroes.Hero
+import com.example.runeboundmagic.heroes.HeroClass
+
+/**
+ * Απλή αναπαράσταση κάρτας ήρωα που εμφανίζεται στο lobby.
+ */
+data class HeroCard(
+    val heroId: String,
+    val name: String,
+    val classType: HeroClass,
+    val cardImage: String
+) {
+    companion object {
+        fun fromHero(hero: Hero): HeroCard = HeroCard(
+            heroId = hero.id,
+            name = hero.name,
+            classType = hero.classType,
+            cardImage = hero.cardImage
+        )
+    }
+}

--- a/app/src/main/java/com/example/runeboundmagic/lobby/LobbyScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/lobby/LobbyScreen.kt
@@ -1,0 +1,38 @@
+package com.example.runeboundmagic.lobby
+
+import com.example.runeboundmagic.heroes.Hero
+import com.example.runeboundmagic.inventory.Inventory
+
+/**
+ * Απλή υλοποίηση του lobby όπου ο παίκτης επιλέγει ήρωα πριν τη μάχη.
+ */
+class LobbyScreen(
+    private val heroes: List<Hero>
+) {
+
+    private var selectedHero: Hero? = null
+    private var customName: String? = null
+
+    fun showHeroCarousel(): List<HeroCard> = heroes.map(HeroCard::fromHero)
+
+    fun enterHeroName(name: String) {
+        customName = name.trim().takeIf { it.isNotEmpty() }
+    }
+
+    fun selectHero(heroId: String) {
+        selectedHero = heroes.firstOrNull { it.id == heroId }
+    }
+
+    fun startBattle(): LobbySelection? = selectedHero?.let { hero ->
+        val resolvedHero = customName?.let { hero.copy(name = it) } ?: hero
+        LobbySelection(
+            hero = resolvedHero,
+            inventory = resolvedHero.createInventory()
+        )
+    }
+
+    data class LobbySelection(
+        val hero: Hero,
+        val inventory: Inventory
+    )
+}


### PR DESCRIPTION
## Summary
- define hero models and hero classes for the Runebound codex
- add inventory, item, rarity, and category representations with basic operations
- implement lobby screen hero card mapping and selection workflow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc5a021bb4832897e7aafcf618be34