### PR TITLE
Add sequence diagram for codex inventory flow

### DIFF
--- a/docs/codex_sequence.puml
+++ b/docs/codex_sequence.puml
@@ -1,0 +1,22 @@
+@startuml
+actor Player
+participant "Game Engine" as Game
+participant "Hero Card UI" as HeroCard
+participant "Inventory UI" as InventoryUI
+participant "Codex Panel" as Codex
+
+Player -> Game: tap "Start Game"
+Game -> HeroCard: loadHero()
+HeroCard -> HeroCard: renderHeroDetails()
+HeroCard -> Player: display()
+
+Player -> HeroCard: openInventory()
+HeroCard -> InventoryUI: showInventory(hero.inventory)
+InventoryUI -> InventoryUI: listItemsByCategory()
+InventoryUI -> Player: display()
+
+Player -> InventoryUI: openCodexCategory(selectedCategory)
+InventoryUI -> Codex: requestCategory(selectedCategory)
+Codex -> InventoryUI: deliverEntries()
+InventoryUI -> Player: renderCodexEntries()
+@enduml


### PR DESCRIPTION
## Summary
- add a PlantUML sequence diagram for the start game to codex category navigation flow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc5e84379483288c235a199e4ba2e1