### PR TITLE
Fix Hero Codex Compose API usage

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/codex/HeroCodexActivity.kt
+++ b/app/src/main/java/com/example/runeboundmagic/codex/HeroCodexActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -30,6 +31,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -113,6 +115,7 @@ class HeroCodexActivity : ComponentActivity() {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun HeroCodexScreen(
     heroName: String,
@@ -282,7 +285,7 @@ private fun HeroCard(
 
             OutlinedCard(
                 colors = CardDefaults.outlinedCardColors(containerColor = Color(0xFF141C3F)),
-                border = CardDefaults.outlinedCardBorder(borderColor = Color(0xFF2A3470))
+                border = BorderStroke(width = 1.dp, color = Color(0xFF2A3470))
             ) {
                 Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     Text(


### PR DESCRIPTION
## Summary
- opt into the Material3 top app bar APIs used by HeroCodexScreen
- switch the outlined card border to use BorderStroke with an explicit width and color

## Testing
- ./gradlew :app:compileDebugKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68deb41cbbf883288b2f9b300a1f16eb