### PR TITLE
Implement battle preparation scene with inventory support

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/HeroType.kt
+++ b/app/src/main/java/com/example/runeboundmagic/HeroType.kt
@@ -7,22 +7,21 @@ package com.example.runeboundmagic
  */
 enum class HeroType {
     WARRIOR,
-    RANGER,
-    PRIESTESS,
+    HUNTER,
     MAGE,
-    BLACK_MAGE
+    PRIEST
 }
 
 fun HeroType.toHeroOption(): HeroOption = when (this) {
     HeroType.WARRIOR -> HeroOption.WARRIOR
-    HeroType.RANGER -> HeroOption.RANGER
-    HeroType.PRIESTESS -> HeroOption.MYSTICAL_PRIESTESS
-    HeroType.MAGE, HeroType.BLACK_MAGE -> HeroOption.MAGE
+    HeroType.HUNTER -> HeroOption.RANGER
+    HeroType.MAGE -> HeroOption.MAGE
+    HeroType.PRIEST -> HeroOption.MYSTICAL_PRIESTESS
 }
 
 fun HeroOption.toHeroType(): HeroType = when (this) {
     HeroOption.WARRIOR -> HeroType.WARRIOR
-    HeroOption.RANGER -> HeroType.RANGER
-    HeroOption.MYSTICAL_PRIESTESS -> HeroType.PRIESTESS
+    HeroOption.RANGER -> HeroType.HUNTER
+    HeroOption.MYSTICAL_PRIESTESS -> HeroType.PRIEST
     HeroOption.MAGE -> HeroType.MAGE
 }

--- a/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationScreen.kt
@@ -1,0 +1,535 @@
+package com.example.runeboundmagic.battleprep
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.runeboundmagic.HeroOption
+import com.example.runeboundmagic.R
+import com.example.runeboundmagic.inventory.InventoryItem
+import com.example.runeboundmagic.inventory.Item
+import com.example.runeboundmagic.inventory.WeaponItem
+import com.example.runeboundmagic.ui.rememberAssetPainter
+
+@OptIn(ExperimentalAnimationApi::class, ExperimentalFoundationApi::class)
+@Composable
+fun BattlePreparationScreen(
+    heroOption: HeroOption,
+    heroName: String,
+    onBack: () -> Unit,
+    onStartBattle: (HeroOption, String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val displayName = stringResource(id = heroOption.displayNameRes)
+    val heroLore = stringResource(id = heroOption.descriptionRes)
+    val viewModel = battlePreparationViewModel(heroOption, heroName, heroLore)
+    val uiState by viewModel.uiState.collectAsState()
+    var selectedCategory by rememberSaveable { mutableStateOf<InventoryCategoryInfo?>(null) }
+
+    LaunchedEffect(uiState.isBackpackOpen) {
+        if (!uiState.isBackpackOpen) {
+            selectedCategory = null
+        }
+    }
+
+    Scaffold(
+        modifier = modifier.fillMaxSize(),
+        containerColor = Color(0xFF090F1F)
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(Color(0xFF0B1533), Color(0xFF131D45))
+                    )
+                )
+        ) {
+            Column(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(horizontal = 24.dp, vertical = 32.dp),
+                verticalArrangement = Arrangement.spacedBy(24.dp)
+            ) {
+                HeroHeader(
+                    onBack = onBack,
+                    title = stringResource(id = R.string.battle_prep_title),
+                    heroLabel = displayName
+                )
+                HeroCardSection(uiState = uiState)
+                InventorySummary(uiState = uiState)
+            }
+
+            InventoryToggle(
+                isOpen = uiState.isBackpackOpen,
+                onToggle = viewModel::toggleBackpack,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = 24.dp, end = 24.dp)
+            )
+
+            AnimatedVisibility(
+                visible = uiState.isBackpackOpen,
+                enter = slideInVertically { -it / 2 } + fadeIn(),
+                exit = slideOutVertically { -it / 2 } + fadeOut(),
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = 96.dp, end = 24.dp)
+            ) {
+                InventoryOverlay(
+                    uiState = uiState,
+                    selectedCategory = selectedCategory,
+                    onCategorySelected = { selectedCategory = it },
+                    onSlotClick = viewModel::selectSlot
+                )
+            }
+
+            StartBattleSection(
+                heroOption = heroOption,
+                heroName = uiState.heroCard?.hero?.name ?: heroName.ifBlank { displayName },
+                onStartBattle = onStartBattle,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 32.dp)
+            )
+
+            if (uiState.selectedItem != null) {
+                ItemDetailsDialog(item = uiState.selectedItem, onDismiss = viewModel::dismissItemDetails)
+            }
+
+            uiState.errorMessage?.let { message ->
+                ErrorMessage(message = message, modifier = Modifier.align(Alignment.BottomStart))
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeroHeader(onBack: () -> Unit, title: String, heroLabel: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        IconButton(onClick = onBack, modifier = Modifier.size(48.dp)) {
+            Icon(imageVector = Icons.Default.ArrowBack, contentDescription = null, tint = Color.White)
+        }
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(text = title, style = MaterialTheme.typography.titleLarge.copy(color = Color.White))
+            Text(
+                text = heroLabel,
+                style = MaterialTheme.typography.bodyMedium.copy(color = Color(0xFF9FA8DA))
+            )
+        }
+        Spacer(modifier = Modifier.size(48.dp))
+    }
+}
+
+@Composable
+private fun HeroCardSection(uiState: BattlePreparationUiState) {
+    val heroCard = uiState.heroCard
+    if (heroCard == null) {
+        LoadingCard()
+        return
+    }
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFF111A3A)),
+        shape = RoundedCornerShape(24.dp)
+    ) {
+        Column(modifier = Modifier.padding(24.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                Image(
+                    painter = rememberAssetPainter(assetPath = heroCard.hero.cardImage),
+                    contentDescription = heroCard.hero.name,
+                    modifier = Modifier
+                        .size(140.dp)
+                        .border(2.dp, heroCard.rarity.color, RoundedCornerShape(18.dp))
+                        .padding(4.dp)
+                )
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = heroCard.hero.name,
+                        style = MaterialTheme.typography.headlineSmall.copy(color = Color.White, fontWeight = FontWeight.Bold)
+                    )
+                    Text(
+                        text = heroCard.heroDescription,
+                        style = MaterialTheme.typography.bodyMedium.copy(color = Color(0xFFB0BEC5))
+                    )
+                    RarityChip(rarity = heroCard.rarity)
+                    ClassInfo(heroClassMetadata = heroCard.heroClassMetadata)
+                }
+            }
+            StatsRow(baseStats = heroCard.baseStats)
+        }
+    }
+}
+
+@Composable
+private fun LoadingCard() {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(180.dp),
+        color = Color(0x33111A3A),
+        shape = RoundedCornerShape(24.dp)
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(text = stringResource(id = R.string.loading), color = Color.White)
+        }
+    }
+}
+
+@Composable
+private fun RarityChip(rarity: RarityMetadata) {
+    Surface(
+        color = rarity.color.copy(alpha = 0.2f),
+        shape = RoundedCornerShape(50),
+        border = androidx.compose.foundation.BorderStroke(1.dp, rarity.color)
+    ) {
+        Text(
+            text = rarity.displayName,
+            color = Color.White,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+            style = MaterialTheme.typography.bodySmall
+        )
+    }
+}
+
+@Composable
+private fun ClassInfo(heroClassMetadata: HeroClassMetadata) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = stringResource(id = R.string.battle_prep_weapon_prof, heroClassMetadata.weaponProficiency),
+            color = Color(0xFFCFD8DC),
+            style = MaterialTheme.typography.bodySmall
+        )
+        Text(
+            text = stringResource(id = R.string.battle_prep_armor_prof, heroClassMetadata.armorProficiency),
+            color = Color(0xFFCFD8DC),
+            style = MaterialTheme.typography.bodySmall
+        )
+    }
+}
+
+@Composable
+private fun StatsRow(baseStats: BaseStats) {
+    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        StatBadge(label = "STR", value = baseStats.strength)
+        StatBadge(label = "AGI", value = baseStats.agility)
+        StatBadge(label = "INT", value = baseStats.intellect)
+        StatBadge(label = "FAI", value = baseStats.faith)
+    }
+}
+
+@Composable
+private fun StatBadge(label: String, value: Int) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Surface(
+            shape = CircleShape,
+            color = Color(0xFF1C2550),
+            border = androidx.compose.foundation.BorderStroke(1.dp, Color(0xFF536DFE))
+        ) {
+            Column(
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(text = label, color = Color(0xFFB0BEC5), fontSize = 12.sp)
+                Text(text = value.toString(), color = Color.White, fontWeight = FontWeight.Bold)
+            }
+        }
+    }
+}
+
+@Composable
+private fun InventorySummary(uiState: BattlePreparationUiState) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = Color(0x221C2550),
+        shape = RoundedCornerShape(20.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            SummaryItem(label = stringResource(id = R.string.battle_prep_gold), value = uiState.gold.toString())
+            SummaryItem(label = stringResource(id = R.string.battle_prep_capacity), value = "${uiState.inventorySlots.count { it.item != null }} / ${uiState.capacity}")
+        }
+    }
+}
+
+@Composable
+private fun SummaryItem(label: String, value: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(text = label, color = Color(0xFF90A4AE), fontSize = 14.sp)
+        Text(text = value, color = Color.White, fontWeight = FontWeight.Bold, fontSize = 18.sp)
+    }
+}
+
+@Composable
+private fun InventoryToggle(isOpen: Boolean, onToggle: () -> Unit, modifier: Modifier = Modifier) {
+    val painter = rememberAssetPainter(assetPath = "inventory/inventory.png")
+    Box(modifier = modifier.clickable(onClick = onToggle)) {
+        Image(
+            painter = painter,
+            contentDescription = stringResource(id = R.string.battle_prep_inventory_toggle),
+            modifier = Modifier.size(64.dp)
+        )
+        if (isOpen) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .size(12.dp)
+                    .background(Color(0xFF00C853), CircleShape)
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun InventoryOverlay(
+    uiState: BattlePreparationUiState,
+    selectedCategory: InventoryCategoryInfo?,
+    onCategorySelected: (InventoryCategoryInfo?) -> Unit,
+    onSlotClick: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(24.dp),
+        tonalElevation = 4.dp,
+        color = Color(0xEE111A3A)
+    ) {
+        Row(modifier = Modifier.padding(20.dp), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            CategoryColumn(
+                categories = uiState.categories,
+                selectedCategory = selectedCategory,
+                onCategorySelected = onCategorySelected
+            )
+            Box {
+                Image(
+                    painter = rememberAssetPainter(assetPath = "inventory/backbag.png"),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .width(260.dp)
+                        .height(320.dp)
+                        .padding(end = 8.dp)
+                )
+                InventoryGrid(
+                    slots = uiState.inventorySlots,
+                    onSlotClick = onSlotClick,
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .padding(horizontal = 24.dp, vertical = 32.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CategoryColumn(
+    categories: List<InventoryCategoryInfo>,
+    selectedCategory: InventoryCategoryInfo?,
+    onCategorySelected: (InventoryCategoryInfo?) -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        categories.forEach { category ->
+            val isSelected = selectedCategory?.id == category.id
+            Surface(
+                modifier = Modifier
+                    .width(140.dp)
+                    .clickable { onCategorySelected(if (isSelected) null else category) },
+                color = if (isSelected) Color(0x332E7DFF) else Color.Transparent,
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)) {
+                    Text(
+                        text = category.title,
+                        color = Color.White,
+                        fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal
+                    )
+                    Text(
+                        text = category.description,
+                        color = Color(0xFF90A4AE),
+                        fontSize = 12.sp
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun InventoryGrid(
+    slots: List<InventorySlotUiModel>,
+    onSlotClick: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(5),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier
+    ) {
+        items(slots, key = { it.index }) { slot ->
+            InventorySlotCell(slot = slot, onClick = { onSlotClick(slot.index) })
+        }
+    }
+}
+
+@Composable
+private fun InventorySlotCell(slot: InventorySlotUiModel, onClick: () -> Unit) {
+    val borderColor = when {
+        slot.isSelected -> Color(0xFF4FC3F7)
+        slot.item != null -> Color(0xFF374785)
+        else -> Color(0x552E3A6A)
+    }
+    Surface(
+        modifier = Modifier
+            .size(48.dp)
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(10.dp),
+        color = Color(0x5520315B),
+        border = androidx.compose.foundation.BorderStroke(1.dp, borderColor)
+    ) {
+        slot.item?.let { item ->
+            Image(
+                painter = rememberAssetPainter(assetPath = item.icon),
+                contentDescription = item.name,
+                modifier = Modifier.padding(6.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ItemDetailsDialog(item: Item, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            Button(onClick = onDismiss) { Text(text = stringResource(id = R.string.close)) }
+        },
+        title = { Text(text = item.name) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(text = item.description)
+                Text(text = stringResource(id = R.string.battle_prep_rarity_label, item.rarity.name))
+                when (item) {
+                    is WeaponItem -> {
+                        Text(text = stringResource(id = R.string.battle_prep_weapon_damage, item.damage))
+                        Text(text = stringResource(id = R.string.battle_prep_weapon_element, item.element))
+                        Text(text = stringResource(id = R.string.battle_prep_weapon_speed, item.attackSpeed))
+                    }
+
+                    is InventoryItem -> {
+                        Text(text = stringResource(id = R.string.battle_prep_item_category, item.category.name))
+                    }
+
+                    else -> {}
+                }
+            }
+        }
+    )
+}
+
+@Composable
+private fun ErrorMessage(message: String, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier.padding(24.dp),
+        color = Color(0xAAFF5252),
+        shape = RoundedCornerShape(16.dp)
+    ) {
+        Text(
+            text = message,
+            color = Color.White,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+        )
+    }
+}
+
+@Composable
+private fun StartBattleSection(
+    heroOption: HeroOption,
+    heroName: String,
+    onStartBattle: (HeroOption, String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Button(onClick = { onStartBattle(heroOption, heroName) }, modifier = modifier) {
+        Text(text = stringResource(id = R.string.battle_prep_start_battle))
+    }
+}
+
+@Composable
+private fun battlePreparationViewModel(
+    heroOption: HeroOption,
+    heroName: String,
+    heroDescription: String
+): BattlePreparationViewModel {
+    val context = LocalContext.current
+    val factory = remember(heroOption, heroName, heroDescription, context) {
+        BattlePreparationViewModelFactory(
+            heroOption = heroOption,
+            heroName = heroName,
+            heroDescription = heroDescription,
+            context = context.applicationContext
+        )
+    }
+    return viewModel(factory = factory)
+}

--- a/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationUiState.kt
+++ b/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationUiState.kt
@@ -1,0 +1,24 @@
+package com.example.runeboundmagic.battleprep
+
+import com.example.runeboundmagic.inventory.Item
+
+/**
+ * Μοντέλα κατάστασης για την οθόνη Battle Preparation.
+ */
+data class InventorySlotUiModel(
+    val index: Int,
+    val item: Item?,
+    val isSelected: Boolean
+)
+
+data class BattlePreparationUiState(
+    val isLoading: Boolean = true,
+    val heroCard: HeroCardDetails? = null,
+    val inventorySlots: List<InventorySlotUiModel> = emptyList(),
+    val gold: Int = 0,
+    val capacity: Int = 0,
+    val categories: List<InventoryCategoryInfo> = emptyList(),
+    val isBackpackOpen: Boolean = false,
+    val selectedItem: Item? = null,
+    val errorMessage: String? = null
+)

--- a/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationViewModel.kt
+++ b/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationViewModel.kt
@@ -1,0 +1,319 @@
+package com.example.runeboundmagic.battleprep
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.runeboundmagic.HeroOption
+import com.example.runeboundmagic.HeroType
+import com.example.runeboundmagic.codex.CodexManager
+import com.example.runeboundmagic.data.codex.local.CodexDao
+import com.example.runeboundmagic.data.codex.local.CodexDatabase
+import com.example.runeboundmagic.heroes.Hero
+import com.example.runeboundmagic.heroes.HeroClass
+import com.example.runeboundmagic.inventory.Inventory
+import com.example.runeboundmagic.inventory.Item
+import com.example.runeboundmagic.inventory.ItemCategory
+import com.example.runeboundmagic.inventory.WeaponItem
+import com.example.runeboundmagic.toHeroType
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.Locale
+
+class BattlePreparationViewModel(
+    private val heroOption: HeroOption,
+    private val heroName: String,
+    private val heroDescription: String,
+    private val codexDao: CodexDao,
+    private val codexManager: CodexManager,
+    private val baseStats: BaseStats,
+    private val heroClassMetadata: HeroClassMetadata,
+    private val rarityMetadata: RarityMetadata,
+    private val heroCardAsset: String
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(BattlePreparationUiState())
+    val uiState: StateFlow<BattlePreparationUiState> = _uiState.asStateFlow()
+
+    private val hero: Hero = createHero()
+
+    init {
+        preloadData()
+    }
+
+    fun toggleBackpack() {
+        _uiState.update { state ->
+            state.copy(isBackpackOpen = !state.isBackpackOpen)
+        }
+    }
+
+    fun selectSlot(index: Int) {
+        val slot = _uiState.value.inventorySlots.getOrNull(index) ?: return
+        _uiState.update { state ->
+            state.copy(
+                inventorySlots = state.inventorySlots.map { slotState ->
+                    if (slotState.index == index) slotState.copy(isSelected = !slotState.isSelected)
+                    else slotState.copy(isSelected = false)
+                },
+                selectedItem = if (slot.isSelected) null else slot.item
+            )
+        }
+    }
+
+    fun dismissItemDetails() {
+        _uiState.update { state ->
+            state.copy(
+                inventorySlots = state.inventorySlots.map { it.copy(isSelected = false) },
+                selectedItem = null
+            )
+        }
+    }
+
+    private fun preloadData() {
+        viewModelScope.launch {
+            runCatching {
+                _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+                val profile = codexManager.prepareHeroProfile(hero, hero.name)
+                persistMetadata(profile.inventory)
+                val heroCardDetails = codexDao.getHeroCard(hero.id)?.toDomain(hero, heroDescription)
+                    ?: HeroCardDetails(
+                        hero = hero,
+                        heroDescription = heroDescription,
+                        heroClassMetadata = heroClassMetadata,
+                        rarity = rarityMetadata,
+                        baseStats = baseStats
+                    )
+                val inventorySlots = buildInventorySlots(profile.inventory)
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        heroCard = heroCardDetails,
+                        inventorySlots = inventorySlots,
+                        gold = profile.inventory.gold,
+                        capacity = profile.inventory.capacity,
+                        categories = DefaultCategories,
+                        isBackpackOpen = false,
+                        selectedItem = null
+                    )
+                }
+            }.onFailure { throwable ->
+                _uiState.update { it.copy(isLoading = false, errorMessage = throwable.message) }
+            }
+        }
+    }
+
+    private suspend fun persistMetadata(inventory: Inventory) {
+        codexDao.upsertHeroClass(heroClassMetadata.toEntity())
+        codexDao.upsertRarities(DefaultRarities.map(RarityMetadata::toEntity))
+        codexDao.upsertItemCategories(DefaultCategories.map(InventoryCategoryInfo::toEntity))
+        val details = HeroCardDetails(
+            hero = hero.copy(cardImage = heroCardAsset),
+            heroDescription = heroDescription,
+            heroClassMetadata = heroClassMetadata,
+            rarity = rarityMetadata,
+            baseStats = baseStats
+        )
+        codexDao.upsertHeroCard(details.toEntity(cardId = "${hero.id}_card"))
+        codexManager.updateInventory(
+            com.example.runeboundmagic.codex.HeroProfile(
+                hero = hero,
+                inventory = inventory
+            )
+        )
+    }
+
+    private fun buildInventorySlots(inventory: Inventory): List<InventorySlotUiModel> {
+        val orderedItems = inventory.getAllItems()
+            .sortedWith(compareByDescending<Item> { it is WeaponItem }.thenBy { it.name })
+        val slots = MutableList(SLOT_COUNT) { index ->
+            InventorySlotUiModel(index = index, item = null, isSelected = false)
+        }
+        orderedItems.forEachIndexed { index, item ->
+            if (index < slots.size) {
+                slots[index] = slots[index].copy(item = item)
+            }
+        }
+        return slots
+    }
+
+    private fun createHero(): Hero {
+        val heroClass = when (heroOption) {
+            HeroOption.WARRIOR -> HeroClass.WARRIOR
+            HeroOption.RANGER -> HeroClass.RANGER
+            HeroOption.MAGE -> HeroClass.MAGE
+            HeroOption.MYSTICAL_PRIESTESS -> HeroClass.PRIESTESS
+        }
+        val resolvedName = heroName.ifBlank {
+            heroOption.name.lowercase(Locale.getDefault()).replaceFirstChar { char ->
+                if (char.isLowerCase()) char.titlecase(Locale.getDefault()) else char.toString()
+            }
+        }
+        return Hero(
+            id = heroOption.name.lowercase(Locale.ROOT),
+            name = resolvedName,
+            description = heroDescription,
+            level = 1,
+            classType = heroClass,
+            cardImage = heroCardAsset
+        )
+    }
+
+    companion object {
+        private const val SLOT_COUNT = 40
+
+        val DefaultCategories: List<InventoryCategoryInfo> = listOf(
+            InventoryCategoryInfo(
+                id = ItemCategory.WEAPON.name,
+                title = "Weapons",
+                description = "Όπλα και εργαλεία μάχης."
+            ),
+            InventoryCategoryInfo(
+                id = ItemCategory.ARMOR.name,
+                title = "Armor",
+                description = "Κράνη, θώρακες και προστατευτικά."
+            ),
+            InventoryCategoryInfo(
+                id = ItemCategory.SHIELD.name,
+                title = "Shields",
+                description = "Ασπίδες και αμυντικοί μηχανισμοί."
+            ),
+            InventoryCategoryInfo(
+                id = ItemCategory.ACCESSORY.name,
+                title = "Accessories",
+                description = "Δαχτυλίδια και φυλαχτά."
+            ),
+            InventoryCategoryInfo(
+                id = ItemCategory.CONSUMABLE.name,
+                title = "Consumables",
+                description = "Φίλτρα και προμήθειες."
+            ),
+            InventoryCategoryInfo(
+                id = ItemCategory.SPELL_SCROLL.name,
+                title = "Spells & Scrolls",
+                description = "Μαγικά ξόρκια και πάπυροι."
+            ),
+            InventoryCategoryInfo(
+                id = ItemCategory.RUNE_GEM.name,
+                title = "Runes & Gems",
+                description = "Μαγικοί λίθοι και ρούνοι."
+            ),
+            InventoryCategoryInfo(
+                id = ItemCategory.CRAFTING_MATERIAL.name,
+                title = "Crafting Materials",
+                description = "Υλικά κατασκευών."
+            ),
+            InventoryCategoryInfo(
+                id = ItemCategory.QUEST_ITEM.name,
+                title = "Quest Items",
+                description = "Αντικείμενα αποστολών."
+            ),
+            InventoryCategoryInfo(
+                id = ItemCategory.CURRENCY.name,
+                title = "Gold & Currency",
+                description = "Νόμισμα και οικονομία."
+            ),
+        )
+
+        val DefaultRarities: List<RarityMetadata> = listOf(
+            RarityMetadata("COMMON", "Common", "#BDBDBD"),
+            RarityMetadata("RARE", "Rare", "#4FC3F7"),
+            RarityMetadata("EPIC", "Epic", "#9575CD"),
+            RarityMetadata("LEGENDARY", "Legendary", "#FFB300")
+        )
+    }
+}
+
+class BattlePreparationViewModelFactory(
+    private val heroOption: HeroOption,
+    private val heroName: String,
+    private val heroDescription: String,
+    private val context: android.content.Context
+) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (!modelClass.isAssignableFrom(BattlePreparationViewModel::class.java)) {
+            throw IllegalArgumentException("Unknown ViewModel class")
+        }
+        val database = CodexDatabase.getInstance(context)
+        val codexDao = database.codexDao()
+        val heroType = heroOption.toHeroType()
+        val baseStats = baseStatsFor(heroType)
+        val metadata = heroClassMetadataFor(heroType)
+        val rarity = rarityMetadataFor(heroType)
+        val cardAsset = heroCardAssetFor(heroType)
+        val manager = CodexManager(codexDao = codexDao)
+        @Suppress("UNCHECKED_CAST")
+        return BattlePreparationViewModel(
+            heroOption = heroOption,
+            heroName = heroName,
+            heroDescription = heroDescription,
+            codexDao = codexDao,
+            codexManager = manager,
+            baseStats = baseStats,
+            heroClassMetadata = metadata,
+            rarityMetadata = rarity,
+            heroCardAsset = cardAsset
+        ) as T
+    }
+}
+
+private fun baseStatsFor(heroType: HeroType): BaseStats = when (heroType) {
+    HeroType.WARRIOR -> BaseStats(strength = 18, agility = 12, intellect = 6, faith = 8)
+    HeroType.HUNTER -> BaseStats(strength = 12, agility = 18, intellect = 8, faith = 6)
+    HeroType.MAGE -> BaseStats(strength = 6, agility = 10, intellect = 20, faith = 12)
+    HeroType.PRIEST -> BaseStats(strength = 8, agility = 10, intellect = 14, faith = 18)
+}
+
+private fun heroClassMetadataFor(heroType: HeroType): HeroClassMetadata = when (heroType) {
+    HeroType.WARRIOR -> HeroClassMetadata(
+        id = HeroClass.WARRIOR,
+        name = "Warrior",
+        weaponProficiency = "Crossbows",
+        armorProficiency = "Plate Armor"
+    )
+
+    HeroType.HUNTER -> HeroClassMetadata(
+        id = HeroClass.RANGER,
+        name = "Hunter",
+        weaponProficiency = "Crossbows",
+        armorProficiency = "Leather Armor"
+    )
+
+    HeroType.MAGE -> HeroClassMetadata(
+        id = HeroClass.MAGE,
+        name = "Mage",
+        weaponProficiency = "Magic Rods",
+        armorProficiency = "Mystic Robes"
+    )
+
+    HeroType.PRIEST -> HeroClassMetadata(
+        id = HeroClass.PRIESTESS,
+        name = "Priest",
+        weaponProficiency = "Sacred Rods",
+        armorProficiency = "Blessed Vestments"
+    )
+}
+
+private fun rarityMetadataFor(heroType: HeroType): RarityMetadata = when (heroType) {
+    HeroType.WARRIOR, HeroType.HUNTER, HeroType.PRIEST -> RarityMetadata(
+        id = "RARE",
+        displayName = "Rare",
+        colorHex = "#4FC3F7"
+    )
+
+    HeroType.MAGE -> RarityMetadata(
+        id = "EPIC",
+        displayName = "Epic",
+        colorHex = "#9575CD"
+    )
+}
+
+private fun heroCardAssetFor(heroType: HeroType): String = when (heroType) {
+    HeroType.WARRIOR -> "heroes/warrior_card.png"
+    HeroType.HUNTER -> "heroes/hunter_card.png"
+    HeroType.MAGE -> "heroes/mage_card.png"
+    HeroType.PRIEST -> "heroes/priest_card.png"
+}
+

--- a/app/src/main/java/com/example/runeboundmagic/battleprep/HeroCardModels.kt
+++ b/app/src/main/java/com/example/runeboundmagic/battleprep/HeroCardModels.kt
@@ -1,0 +1,124 @@
+package com.example.runeboundmagic.battleprep
+
+import androidx.compose.ui.graphics.Color
+import com.example.runeboundmagic.data.codex.local.HeroCardEntity
+import com.example.runeboundmagic.data.codex.local.HeroCardWithMetadata
+import com.example.runeboundmagic.data.codex.local.HeroClassMetadataEntity
+import com.example.runeboundmagic.data.codex.local.ItemCategoryEntity
+import com.example.runeboundmagic.data.codex.local.RarityEntity
+import com.example.runeboundmagic.heroes.Hero
+import com.example.runeboundmagic.heroes.HeroClass
+
+/**
+ * Βασικά στατιστικά που εμφανίζονται στην κάρτα ήρωα.
+ */
+data class BaseStats(
+    val strength: Int,
+    val agility: Int,
+    val intellect: Int,
+    val faith: Int
+)
+
+/**
+ * Περιγραφή κλάσης ήρωα για χρήση στο UI και στην τοπική βάση.
+ */
+data class HeroClassMetadata(
+    val id: HeroClass,
+    val name: String,
+    val weaponProficiency: String,
+    val armorProficiency: String
+)
+
+/**
+ * Στοιχεία σπανιότητας.
+ */
+data class RarityMetadata(
+    val id: String,
+    val displayName: String,
+    val colorHex: String
+) {
+    val color: Color
+        get() = runCatching { Color(android.graphics.Color.parseColor(colorHex)) }
+            .getOrDefault(Color(0xFFBDBDBD))
+}
+
+/**
+ * Αναλυτικά στοιχεία για την κάρτα ήρωα του Battle Preparation.
+ */
+data class HeroCardDetails(
+    val hero: Hero,
+    val heroDescription: String,
+    val heroClassMetadata: HeroClassMetadata,
+    val rarity: RarityMetadata,
+    val baseStats: BaseStats
+)
+
+/**
+ * Κατηγορία inventory με σύντομη περιγραφή.
+ */
+data class InventoryCategoryInfo(
+    val id: String,
+    val title: String,
+    val description: String
+)
+
+fun HeroClassMetadata.toEntity(): HeroClassMetadataEntity = HeroClassMetadataEntity(
+    heroClassId = id.name,
+    name = name,
+    weaponProficiency = weaponProficiency,
+    armorProficiency = armorProficiency
+)
+
+fun RarityMetadata.toEntity(): RarityEntity = RarityEntity(
+    rarityId = id,
+    displayName = displayName,
+    colorHex = colorHex
+)
+
+fun InventoryCategoryInfo.toEntity(): ItemCategoryEntity = ItemCategoryEntity(
+    itemCategoryId = id,
+    displayName = title,
+    description = description,
+    slotType = id
+)
+
+fun HeroCardWithMetadata.toDomain(hero: Hero, description: String): HeroCardDetails {
+    val heroClassMetadata = HeroClassMetadata(
+        id = runCatching { HeroClass.valueOf(heroClass.heroClassId) }.getOrDefault(hero.classType),
+        name = heroClass.name,
+        weaponProficiency = heroClass.weaponProficiency,
+        armorProficiency = heroClass.armorProficiency
+    )
+    val rarity = rarity?.let {
+        RarityMetadata(
+            id = it.rarityId,
+            displayName = it.displayName,
+            colorHex = it.colorHex
+        )
+    } ?: RarityMetadata(id = "COMMON", displayName = "Common", colorHex = "#BDBDBD")
+    return HeroCardDetails(
+        hero = hero.copy(cardImage = card.cardImage),
+        heroDescription = description,
+        heroClassMetadata = heroClassMetadata,
+        rarity = rarity,
+        baseStats = BaseStats(
+            strength = card.strength,
+            agility = card.agility,
+            intellect = card.intellect,
+            faith = card.faith
+        )
+    )
+}
+
+fun HeroCardDetails.toEntity(cardId: String): HeroCardEntity = HeroCardEntity(
+    heroCardId = cardId,
+    heroId = hero.id,
+    heroClassId = heroClassMetadata.id.name,
+    heroName = hero.name,
+    cardImage = hero.cardImage,
+    strength = baseStats.strength,
+    agility = baseStats.agility,
+    intellect = baseStats.intellect,
+    faith = baseStats.faith,
+    rarityId = rarity.id
+)

--- a/app/src/main/java/com/example/runeboundmagic/codex/CodexManager.kt
+++ b/app/src/main/java/com/example/runeboundmagic/codex/CodexManager.kt
@@ -8,6 +8,7 @@ import com.example.runeboundmagic.inventory.InventoryItem
 import com.example.runeboundmagic.inventory.ItemCategory
 import com.example.runeboundmagic.inventory.Item
 import com.example.runeboundmagic.inventory.Rarity
+import com.example.runeboundmagic.inventory.WeaponItem
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -111,21 +112,52 @@ private object DefaultEquipmentLoadout {
         return listOf(weapon) + otherCategories
     }
 
-    private fun weaponFor(heroClass: HeroClass, prefix: String): InventoryItem {
-        val (name, icon, rarity) = when (heroClass) {
-            HeroClass.WARRIOR -> Triple("Λεπίδα Εκκίνησης", "weapon/sword.png", Rarity.RARE)
-            HeroClass.RANGER -> Triple("Κυνηγετικό Τόξο", "weapon/crossbow.png", Rarity.RARE)
-            HeroClass.MAGE -> Triple("Ραβδί Πυροφλόγας", "weapon/rod.png", Rarity.EPIC)
-            HeroClass.PRIESTESS -> Triple("Ραβδί Φωτός", "weapon/rod.png", Rarity.RARE)
+    private fun weaponFor(heroClass: HeroClass, prefix: String): WeaponItem {
+        return when (heroClass) {
+            HeroClass.WARRIOR -> WeaponItem(
+                id = "${'$'}prefix_weapon",
+                name = "Βολίδα Μάχης",
+                description = "Ελαφρύ βαλλίστρα που επιτρέπει γρήγορες επιθέσεις πριν τη σύγκρουση.",
+                icon = "weapon/crossbow.png",
+                rarity = Rarity.RARE,
+                damage = 24,
+                element = "PIERCING",
+                attackSpeed = 1.3f
+            )
+
+            HeroClass.RANGER -> WeaponItem(
+                id = "${'$'}prefix_weapon",
+                name = "Κυνηγετικό Τόξο",
+                description = "Αξιόπιστη βαλλίστρα για τους κυνηγούς των Runebound Lands.",
+                icon = "weapon/crossbow.png",
+                rarity = Rarity.RARE,
+                damage = 22,
+                element = "PIERCING",
+                attackSpeed = 1.45f
+            )
+
+            HeroClass.MAGE -> WeaponItem(
+                id = "${'$'}prefix_weapon",
+                name = "Ραβδί Αιθέρα",
+                description = "Μαγεμένο ραβδί με μπλε αύρα που επικαλείται στοιχειακή ενέργεια.",
+                icon = "weapon/rod.png",
+                rarity = Rarity.EPIC,
+                damage = 18,
+                element = "ARCANE",
+                attackSpeed = 1.1f
+            )
+
+            HeroClass.PRIESTESS -> WeaponItem(
+                id = "${'$'}prefix_weapon",
+                name = "Ραβδί Φωτεινών Ρούνων",
+                description = "Ιερό ραβδί με φωτεινά runes που ενισχύει τα ξόρκια θεραπείας.",
+                icon = "weapon/rod.png",
+                rarity = Rarity.RARE,
+                damage = 16,
+                element = "HOLY",
+                attackSpeed = 1.2f
+            )
         }
-        return InventoryItem(
-            id = "${'$'}prefix_weapon",
-            name = name,
-            description = "Αρχικό όπλο που προσαρμόζεται στην κλάση του ήρωα.",
-            icon = icon,
-            rarity = rarity,
-            category = ItemCategory.WEAPON
-        )
     }
 
     private fun defaultItem(category: ItemCategory, prefix: String): InventoryItem? = when (category) {

--- a/app/src/main/java/com/example/runeboundmagic/data/codex/local/CodexDao.kt
+++ b/app/src/main/java/com/example/runeboundmagic/data/codex/local/CodexDao.kt
@@ -13,6 +13,10 @@ interface CodexDao {
     @Query("SELECT * FROM codex_heroes WHERE heroId = :heroId")
     suspend fun getHeroWithInventory(heroId: String): HeroWithInventory?
 
+    @Transaction
+    @Query("SELECT * FROM hero_cards WHERE heroId = :heroId LIMIT 1")
+    suspend fun getHeroCard(heroId: String): HeroCardWithMetadata?
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertHero(hero: CodexHeroEntity)
 
@@ -21,6 +25,18 @@ interface CodexDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertItems(items: List<CodexInventoryItemEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertHeroClass(metadata: HeroClassMetadataEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertHeroCard(card: HeroCardEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertRarities(entries: List<RarityEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertItemCategories(entries: List<ItemCategoryEntity>)
 
     @Query("DELETE FROM codex_items WHERE inventoryId = :inventoryId")
     suspend fun clearItems(inventoryId: String)

--- a/app/src/main/java/com/example/runeboundmagic/data/codex/local/CodexDatabase.kt
+++ b/app/src/main/java/com/example/runeboundmagic/data/codex/local/CodexDatabase.kt
@@ -10,9 +10,13 @@ import androidx.room.TypeConverters
     entities = [
         CodexHeroEntity::class,
         CodexInventoryEntity::class,
-        CodexInventoryItemEntity::class
+        CodexInventoryItemEntity::class,
+        HeroClassMetadataEntity::class,
+        RarityEntity::class,
+        ItemCategoryEntity::class,
+        HeroCardEntity::class
     ],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 @TypeConverters(CodexTypeConverters::class)

--- a/app/src/main/java/com/example/runeboundmagic/data/codex/local/CodexEntities.kt
+++ b/app/src/main/java/com/example/runeboundmagic/data/codex/local/CodexEntities.kt
@@ -21,6 +21,70 @@ data class CodexHeroEntity(
     val inventoryId: String
 )
 
+@Entity(tableName = "hero_classes")
+data class HeroClassMetadataEntity(
+    @PrimaryKey val heroClassId: String,
+    val name: String,
+    val weaponProficiency: String,
+    val armorProficiency: String
+)
+
+@Entity(tableName = "rarities")
+data class RarityEntity(
+    @PrimaryKey val rarityId: String,
+    val displayName: String,
+    val colorHex: String
+)
+
+@Entity(tableName = "item_categories")
+data class ItemCategoryEntity(
+    @PrimaryKey val itemCategoryId: String,
+    val displayName: String,
+    val description: String,
+    val slotType: String
+)
+
+@Entity(
+    tableName = "hero_cards",
+    foreignKeys = [
+        ForeignKey(
+            entity = CodexHeroEntity::class,
+            parentColumns = ["heroId"],
+            childColumns = ["heroId"],
+            onDelete = ForeignKey.CASCADE
+        ),
+        ForeignKey(
+            entity = HeroClassMetadataEntity::class,
+            parentColumns = ["heroClassId"],
+            childColumns = ["heroClassId"],
+            onDelete = ForeignKey.NO_ACTION
+        ),
+        ForeignKey(
+            entity = RarityEntity::class,
+            parentColumns = ["rarityId"],
+            childColumns = ["rarityId"],
+            onDelete = ForeignKey.NO_ACTION
+        )
+    ],
+    indices = [
+        Index("heroId", unique = true),
+        Index("heroClassId"),
+        Index("rarityId")
+    ]
+)
+data class HeroCardEntity(
+    @PrimaryKey val heroCardId: String,
+    val heroId: String,
+    val heroClassId: String,
+    val heroName: String,
+    val cardImage: String,
+    val strength: Int,
+    val agility: Int,
+    val intellect: Int,
+    val faith: Int,
+    val rarityId: String
+)
+
 @Entity(
     tableName = "codex_inventories",
     foreignKeys = [
@@ -60,7 +124,25 @@ data class CodexInventoryItemEntity(
     val description: String,
     val icon: String,
     val rarity: Rarity,
-    val category: ItemCategory
+    val category: ItemCategory,
+    val rarityId: String,
+    val damage: Int? = null,
+    val element: String? = null,
+    val attackSpeed: Float? = null
+)
+
+data class HeroCardWithMetadata(
+    @Embedded val card: HeroCardEntity,
+    @Relation(
+        parentColumn = "heroClassId",
+        entityColumn = "heroClassId"
+    )
+    val heroClass: HeroClassMetadataEntity,
+    @Relation(
+        parentColumn = "rarityId",
+        entityColumn = "rarityId"
+    )
+    val rarity: RarityEntity?
 )
 
 data class CodexInventoryWithItems(

--- a/app/src/main/java/com/example/runeboundmagic/data/local/HeroTypeConverter.kt
+++ b/app/src/main/java/com/example/runeboundmagic/data/local/HeroTypeConverter.kt
@@ -10,5 +10,5 @@ class HeroTypeConverter {
     @TypeConverter
     fun toHeroType(value: String): HeroType = runCatching {
         HeroType.valueOf(value)
-    }.getOrDefault(HeroType.PRIESTESS)
+    }.getOrDefault(HeroType.PRIEST)
 }

--- a/app/src/main/java/com/example/runeboundmagic/ui/RuneboundMagicApp.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/RuneboundMagicApp.kt
@@ -10,6 +10,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.example.runeboundmagic.HeroOption
 import com.example.runeboundmagic.audio.BackgroundMusicController
+import com.example.runeboundmagic.battleprep.BattlePreparationScreen
 import com.example.runeboundmagic.codex.CodexScreen
 
 private const val SplashRoute = "splash"
@@ -17,6 +18,7 @@ private const val IntroRoute = "intro"
 private const val LobbyRoute = "lobby"
 private const val CodexRoute = "codex"
 private const val Match3Route = "match3"
+private const val BattlePreparationRoute = "battle_prep"
 
 private val SplashColorScheme = darkColorScheme(
     primary = Color(0xFF38B6FF),
@@ -54,12 +56,29 @@ fun RuneboundMagicApp(musicController: BackgroundMusicController) {
                     onStartBattle = { hero: HeroOption, heroName ->
                         musicController.stop()
                         val encodedName = Uri.encode(heroName)
-                        navController.navigate("${Routes.Match3}/${hero.name}/$encodedName")
+                        navController.navigate("${Routes.BattlePreparation}/${hero.name}/$encodedName")
                     },
                     onOpenCodex = {
                         navController.navigate(Routes.Codex)
                     },
                     onLobbyShown = { musicController.startOrResume() }
+                )
+            }
+            composable("$BattlePreparationRoute/{hero}/{player}") { backStackEntry ->
+                val heroArg = backStackEntry.arguments?.getString("hero")
+                val playerArg = backStackEntry.arguments?.getString("player") ?: ""
+                val selectedHero = HeroOption.fromName(heroArg)
+                val heroName = Uri.decode(playerArg)
+                BattlePreparationScreen(
+                    heroOption = selectedHero,
+                    heroName = heroName,
+                    onBack = { navController.popBackStack() },
+                    onStartBattle = { heroOption, playerName ->
+                        val encoded = Uri.encode(playerName)
+                        navController.navigate("${Routes.Match3}/${heroOption.name}/$encoded") {
+                            popUpTo(Routes.BattlePreparation) { inclusive = true }
+                        }
+                    }
                 )
             }
             composable("$Match3Route/{hero}/{player}") { backStackEntry ->
@@ -88,5 +107,6 @@ internal object Routes {
     const val Intro = IntroRoute
     const val Lobby = LobbyRoute
     const val Codex = CodexRoute
+    const val BattlePreparation = BattlePreparationRoute
     const val Match3 = Match3Route
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,4 +68,18 @@
     <string name="match3_enemy_subtitle">Σκοτεινός άρχοντας των ρούνων</string>
     <string name="match3_vs">VS</string>
     <string name="match3_hint">Πάτησε δύο ρούνους για να τους ανταλλάξεις και να φορτίσεις τη δύναμή σου.</string>
+    <string name="loading">Φόρτωση…</string>
+    <string name="battle_prep_title">Προετοιμασία Μάχης</string>
+    <string name="battle_prep_weapon_prof">Όπλα: %1$s</string>
+    <string name="battle_prep_armor_prof">Πανοπλία: %1$s</string>
+    <string name="battle_prep_gold">Χρυσός</string>
+    <string name="battle_prep_capacity">Χωρητικότητα</string>
+    <string name="battle_prep_inventory_toggle">Άνοιγμα σακιδίου</string>
+    <string name="battle_prep_rarity_label">Σπανιότητα: %1$s</string>
+    <string name="battle_prep_weapon_damage">Ζημιά: %1$d</string>
+    <string name="battle_prep_weapon_element">Στοιχείο: %1$s</string>
+    <string name="battle_prep_weapon_speed">Ταχύτητα Επίθεσης: %1$.2f</string>
+    <string name="battle_prep_item_category">Κατηγορία: %1$s</string>
+    <string name="battle_prep_start_battle">Έναρξη Μάχης</string>
+    <string name="close">Κλείσιμο</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a dedicated BattlePreparation screen that presents the selected hero card, inventory grid and item tooltips before the match
- back the scene with a new ViewModel, UI state models and Room metadata tables for hero cards, rarities, categories and weapon stats
- extend inventory items to support weapon attributes, adjust default loadouts, update navigation to route through the preparation scene and refresh localized strings

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5e1c6c088832886defb839a02d70b