### PR TITLE
Fix inventory loadout types and item dialog handling

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationScreen.kt
@@ -147,8 +147,8 @@ fun BattlePreparationScreen(
                     .padding(bottom = 32.dp)
             )
 
-            if (uiState.selectedItem != null) {
-                ItemDetailsDialog(item = uiState.selectedItem, onDismiss = viewModel::dismissItemDetails)
+            uiState.selectedItem?.let { item ->
+                ItemDetailsDialog(item = item, onDismiss = viewModel::dismissItemDetails)
             }
 
             uiState.errorMessage?.let { message ->

--- a/app/src/main/java/com/example/runeboundmagic/codex/CodexManager.kt
+++ b/app/src/main/java/com/example/runeboundmagic/codex/CodexManager.kt
@@ -103,13 +103,16 @@ class CodexManager(
 
 private object DefaultEquipmentLoadout {
 
-    fun loadoutFor(heroClass: HeroClass): List<InventoryItem> {
+    fun loadoutFor(heroClass: HeroClass): List<Item> {
         val prefix = heroClass.name.lowercase()
         val weapon = weaponFor(heroClass, prefix)
         val otherCategories = ItemCategory.values()
             .filter { it != ItemCategory.WEAPON }
             .mapNotNull { category -> defaultItem(category, prefix) }
-        return listOf(weapon) + otherCategories
+        return buildList {
+            add(weapon)
+            addAll(otherCategories)
+        }
     }
 
     private fun weaponFor(heroClass: HeroClass, prefix: String): WeaponItem {
@@ -160,7 +163,7 @@ private object DefaultEquipmentLoadout {
         }
     }
 
-    private fun defaultItem(category: ItemCategory, prefix: String): InventoryItem? = when (category) {
+    private fun defaultItem(category: ItemCategory, prefix: String): Item? = when (category) {
         ItemCategory.ARMOR -> baseItem(
             prefix,
             category,
@@ -245,7 +248,7 @@ private object DefaultEquipmentLoadout {
         description: String,
         icon: String,
         rarity: Rarity = Rarity.COMMON
-    ): InventoryItem = InventoryItem(
+    ): Item = InventoryItem(
         id = "${'$'}prefix_${'$'}{category.name.lowercase()}_01",
         name = name,
         description = description,


### PR DESCRIPTION
## Summary
- αποτρέπεται το σφάλμα smart cast στο παράθυρο λεπτομερειών αντικειμένου χρησιμοποιώντας ασφαλές `let`
- ενημερώνεται το default loadout ώστε να επιστρέφει λίστα `Item` που υποστηρίζει όπλα και γενικά αντικείμενα

## Testing
- ./gradlew :app:compileDebugKotlin *(αποτυγχάνει: λείπει Android SDK στο περιβάλλον CI)*

------
https://chatgpt.com/codex/tasks/task_e_68e5e8a1a0808328bbca4c817bd191a7