### PR TITLE
Fix null-check for selected item dialog

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationScreen.kt
@@ -147,8 +147,9 @@ fun BattlePreparationScreen(
                     .padding(bottom = 32.dp)
             )
 
-            if (uiState.selectedItem != null) {
-                ItemDetailsDialog(item = uiState.selectedItem, onDismiss = viewModel::dismissItemDetails)
+            val selectedItem = uiState.selectedItem
+            if (selectedItem != null) {
+                ItemDetailsDialog(item = selectedItem, onDismiss = viewModel::dismissItemDetails)
             }
 
             uiState.errorMessage?.let { message ->


### PR DESCRIPTION
## Summary
- store the selected item in a local variable before showing the details dialog
- avoid Kotlin smart cast issue caused by delegated ui state property

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5e9c0c01883289ecc623ae7ee7bed