### PR TITLE
Refine battle preparation screen layout

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationUiState.kt
+++ b/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationUiState.kt
@@ -18,7 +18,6 @@ data class BattlePreparationUiState(
     val gold: Int = 0,
     val capacity: Int = 0,
     val categories: List<InventoryCategoryInfo> = emptyList(),
-    val isBackpackOpen: Boolean = false,
     val selectedItem: Item? = null,
     val errorMessage: String? = null
 )

--- a/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationViewModel.kt
+++ b/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationViewModel.kt
@@ -43,12 +43,6 @@ class BattlePreparationViewModel(
         preloadData()
     }
 
-    fun toggleBackpack() {
-        _uiState.update { state ->
-            state.copy(isBackpackOpen = !state.isBackpackOpen)
-        }
-    }
-
     fun selectSlot(index: Int) {
         val slot = _uiState.value.inventorySlots.getOrNull(index) ?: return
         _uiState.update { state ->
@@ -94,7 +88,6 @@ class BattlePreparationViewModel(
                         gold = profile.inventory.gold,
                         capacity = profile.inventory.capacity,
                         categories = DefaultCategories,
-                        isBackpackOpen = false,
                         selectedItem = null
                     )
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,6 +74,10 @@
     <string name="battle_prep_armor_prof">Πανοπλία: %1$s</string>
     <string name="battle_prep_gold">Χρυσός</string>
     <string name="battle_prep_capacity">Χωρητικότητα</string>
+    <string name="battle_prep_inventory_slots">%1$d / %2$d</string>
+    <string name="battle_prep_equipment_title">Εξοπλισμός</string>
+    <string name="battle_prep_equipment_weapon">Όπλο: %1$s</string>
+    <string name="battle_prep_equipment_armor">Πανοπλία: %1$s</string>
     <string name="battle_prep_inventory_toggle">Άνοιγμα σακιδίου</string>
     <string name="battle_prep_rarity_label">Σπανιότητα: %1$s</string>
     <string name="battle_prep_weapon_damage">Ζημιά: %1$d</string>


### PR DESCRIPTION
## Summary
- redesign the battle preparation screen to show the hero card, stats, and inventory within a single gradient layout
- surface hero class and equipment details alongside cleaned-up inventory capacity formatting
- replace the backpack overlay with an 8x5 interactive inventory grid and category column on a neutral surface

## Testing
- ./gradlew :app:lintDebug *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5ef788a348328a55e6867b0d733f1