### PR TITLE
Set launcher icon to app logo

### DIFF
--- a/app/src/main/res/mipmap-anydpi/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi/ic_launcher.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
-    <foreground android:drawable="@drawable/ic_launcher_foreground" />
-    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+    <foreground android:drawable="@drawable/logo" />
+    <monochrome android:drawable="@drawable/logo" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi/ic_launcher_round.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
-    <foreground android:drawable="@drawable/ic_launcher_foreground" />
-    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+    <foreground android:drawable="@drawable/logo" />
+    <monochrome android:drawable="@drawable/logo" />
 </adaptive-icon>


### PR DESCRIPTION
## Summary
- update the adaptive launcher icons to reference the existing app logo for both standard and round variants

## Testing
- ./gradlew lint *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e601d18e3c8328b50aa5b58a05dfac