### PR TITLE
Fix Runebound Magic naming typos

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.RouneboundMagic">
+        android:theme="@style/Theme.RuneboundMagic">
         <activity
             android:name=".CrashReportActivity"
             android:exported="false"

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.RouneboundMagic" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.RuneboundMagic" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_200</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Rounebound Magic</string>
+    <string name="app_name">Runebound Magic</string>
     <string name="lobby_select_hero">Επιλογή Ήρωα</string>
     <string name="lobby_select_hero_with_choice">Επιλογή Ήρωα (%1$s)</string>
     <string name="lobby_selected_hero_details">Ήρωας: %1$s – %2$s</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.RouneboundMagic" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.RuneboundMagic" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>


### PR DESCRIPTION
## Summary
- correct the app display name to "Runebound Magic"
- align the theme resource names and manifest reference with the corrected spelling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e603b0fdac83288b8ec0db1a4aab76