### PR TITLE
Implement structured inventory categories and slot rules

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationViewModel.kt
+++ b/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationViewModel.kt
@@ -13,7 +13,6 @@ import com.example.runeboundmagic.heroes.HeroClass
 import com.example.runeboundmagic.inventory.Inventory
 import com.example.runeboundmagic.inventory.Item
 import com.example.runeboundmagic.inventory.ItemCategory
-import com.example.runeboundmagic.inventory.WeaponItem
 import com.example.runeboundmagic.toHeroType
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -93,7 +92,7 @@ class BattlePreparationViewModel(
                         inventorySlots = inventorySlots,
                         gold = profile.inventory.gold,
                         capacity = profile.inventory.capacity,
-                        categories = DefaultCategories,
+                        categories = buildCategoryOverview(profile.inventory),
                         isBackpackOpen = false,
                         selectedItem = null
                     )
@@ -126,7 +125,7 @@ class BattlePreparationViewModel(
 
     private fun buildInventorySlots(inventory: Inventory): List<InventorySlotUiModel> {
         val orderedItems = inventory.getAllItems()
-            .sortedWith(compareByDescending<Item> { it is WeaponItem }.thenBy { it.name })
+            .sortedWith(compareByDescending<Item> { it.category == ItemCategory.WEAPONS }.thenBy { it.name })
         val slots = MutableList(SLOT_COUNT) { index ->
             InventorySlotUiModel(index = index, item = null, isSelected = false)
         }
@@ -136,6 +135,18 @@ class BattlePreparationViewModel(
             }
         }
         return slots
+    }
+
+    private fun buildCategoryOverview(inventory: Inventory): List<InventoryCategoryInfo> {
+        val categoriesCount = DefaultCategories.size.coerceAtLeast(1)
+        val baseCapacity = inventory.capacity / categoriesCount
+        val remainder = inventory.capacity % categoriesCount
+        return DefaultCategories.mapIndexed { index, info ->
+            val category = runCatching { ItemCategory.valueOf(info.id) }.getOrDefault(ItemCategory.WEAPONS)
+            val owned = inventory.getItemsByCategory(category).size
+            val capacity = baseCapacity + if (index < remainder) 1 else 0
+            info.copy(owned = owned, capacity = capacity)
+        }
     }
 
     private fun createHero(): Hero {
@@ -165,54 +176,64 @@ class BattlePreparationViewModel(
 
         val DefaultCategories: List<InventoryCategoryInfo> = listOf(
             InventoryCategoryInfo(
-                id = ItemCategory.WEAPON.name,
+                id = ItemCategory.WEAPONS.name,
                 title = "Weapons",
-                description = "Όπλα και εργαλεία μάχης."
+                description = "Όπλα και εργαλεία μάχης.",
+                iconAsset = "weapon/rod.png"
             ),
             InventoryCategoryInfo(
                 id = ItemCategory.ARMOR.name,
                 title = "Armor",
-                description = "Κράνη, θώρακες και προστατευτικά."
+                description = "Κράνη, θώρακες και προστατευτικά.",
+                iconAsset = "armor/chest.png"
             ),
             InventoryCategoryInfo(
-                id = ItemCategory.SHIELD.name,
+                id = ItemCategory.SHIELDS.name,
                 title = "Shields",
-                description = "Ασπίδες και αμυντικοί μηχανισμοί."
+                description = "Ασπίδες και αμυντικοί μηχανισμοί.",
+                iconAsset = "armor/helmet.png"
             ),
             InventoryCategoryInfo(
-                id = ItemCategory.ACCESSORY.name,
+                id = ItemCategory.ACCESSORIES.name,
                 title = "Accessories",
-                description = "Δαχτυλίδια και φυλαχτά."
+                description = "Δαχτυλίδια και φυλαχτά.",
+                iconAsset = "armor/gloves.png"
             ),
             InventoryCategoryInfo(
-                id = ItemCategory.CONSUMABLE.name,
+                id = ItemCategory.CONSUMABLES.name,
                 title = "Consumables",
-                description = "Φίλτρα και προμήθειες."
+                description = "Φίλτρα και προμήθειες.",
+                iconAsset = "inventory/inventory.png"
             ),
             InventoryCategoryInfo(
-                id = ItemCategory.SPELL_SCROLL.name,
+                id = ItemCategory.SPELLS_SCROLLS.name,
                 title = "Spells & Scrolls",
-                description = "Μαγικά ξόρκια και πάπυροι."
+                description = "Μαγικά ξόρκια και πάπυροι.",
+                iconAsset = "characters/mage.png"
             ),
             InventoryCategoryInfo(
-                id = ItemCategory.RUNE_GEM.name,
+                id = ItemCategory.RUNES_GEMS.name,
                 title = "Runes & Gems",
-                description = "Μαγικοί λίθοι και ρούνοι."
+                description = "Μαγικοί λίθοι και ρούνοι.",
+                iconAsset = "puzzle/circle.png"
             ),
             InventoryCategoryInfo(
-                id = ItemCategory.CRAFTING_MATERIAL.name,
+                id = ItemCategory.CRAFTING_MATERIALS.name,
                 title = "Crafting Materials",
-                description = "Υλικά κατασκευών."
+                description = "Υλικά κατασκευών.",
+                iconAsset = "armor/chest-women_b.png"
             ),
             InventoryCategoryInfo(
-                id = ItemCategory.QUEST_ITEM.name,
+                id = ItemCategory.QUEST_ITEMS.name,
                 title = "Quest Items",
-                description = "Αντικείμενα αποστολών."
+                description = "Αντικείμενα αποστολών.",
+                iconAsset = "inventory/backbag.png"
             ),
             InventoryCategoryInfo(
-                id = ItemCategory.CURRENCY.name,
+                id = ItemCategory.GOLD_CURRENCY.name,
                 title = "Gold & Currency",
-                description = "Νόμισμα και οικονομία."
+                description = "Νόμισμα και οικονομία.",
+                iconAsset = "inventory/inventory.png"
             ),
         )
 

--- a/app/src/main/java/com/example/runeboundmagic/battleprep/HeroCardModels.kt
+++ b/app/src/main/java/com/example/runeboundmagic/battleprep/HeroCardModels.kt
@@ -59,7 +59,10 @@ data class HeroCardDetails(
 data class InventoryCategoryInfo(
     val id: String,
     val title: String,
-    val description: String
+    val description: String,
+    val iconAsset: String,
+    val owned: Int = 0,
+    val capacity: Int = 0
 )
 
 fun HeroClassMetadata.toEntity(): HeroClassMetadataEntity = HeroClassMetadataEntity(

--- a/app/src/main/java/com/example/runeboundmagic/codex/CodexManager.kt
+++ b/app/src/main/java/com/example/runeboundmagic/codex/CodexManager.kt
@@ -5,10 +5,11 @@ import com.example.runeboundmagic.heroes.Hero
 import com.example.runeboundmagic.heroes.HeroClass
 import com.example.runeboundmagic.inventory.Inventory
 import com.example.runeboundmagic.inventory.InventoryItem
-import com.example.runeboundmagic.inventory.ItemCategory
 import com.example.runeboundmagic.inventory.Item
+import com.example.runeboundmagic.inventory.ItemCategory
+import com.example.runeboundmagic.inventory.ItemSubcategory
 import com.example.runeboundmagic.inventory.Rarity
-import com.example.runeboundmagic.inventory.WeaponItem
+import com.example.runeboundmagic.inventory.WeaponStats
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -107,7 +108,7 @@ private object DefaultEquipmentLoadout {
         val prefix = heroClass.name.lowercase()
         val weapon = weaponFor(heroClass, prefix)
         val otherCategories = ItemCategory.values()
-            .filter { it != ItemCategory.WEAPON }
+            .filter { it != ItemCategory.WEAPONS }
             .mapNotNull { category -> defaultItem(category, prefix) }
         return buildList {
             add(weapon)
@@ -115,50 +116,50 @@ private object DefaultEquipmentLoadout {
         }
     }
 
-    private fun weaponFor(heroClass: HeroClass, prefix: String): WeaponItem {
+    private fun weaponFor(heroClass: HeroClass, prefix: String): Item {
         return when (heroClass) {
-            HeroClass.WARRIOR -> WeaponItem(
+            HeroClass.WARRIOR -> InventoryItem(
                 id = "${'$'}prefix_weapon",
                 name = "Βολίδα Μάχης",
                 description = "Ελαφρύ βαλλίστρα που επιτρέπει γρήγορες επιθέσεις πριν τη σύγκρουση.",
                 icon = "weapon/crossbow.png",
                 rarity = Rarity.RARE,
-                damage = 24,
-                element = "PIERCING",
-                attackSpeed = 1.3f
+                category = ItemCategory.WEAPONS,
+                subcategory = ItemSubcategory.CROSSBOW,
+                weaponStats = WeaponStats(damage = 24, element = "PIERCING", attackSpeed = 1.3f)
             )
 
-            HeroClass.RANGER -> WeaponItem(
+            HeroClass.RANGER -> InventoryItem(
                 id = "${'$'}prefix_weapon",
                 name = "Κυνηγετικό Τόξο",
                 description = "Αξιόπιστη βαλλίστρα για τους κυνηγούς των Runebound Lands.",
                 icon = "weapon/crossbow.png",
                 rarity = Rarity.RARE,
-                damage = 22,
-                element = "PIERCING",
-                attackSpeed = 1.45f
+                category = ItemCategory.WEAPONS,
+                subcategory = ItemSubcategory.CROSSBOW,
+                weaponStats = WeaponStats(damage = 22, element = "PIERCING", attackSpeed = 1.45f)
             )
 
-            HeroClass.MAGE -> WeaponItem(
+            HeroClass.MAGE -> InventoryItem(
                 id = "${'$'}prefix_weapon",
                 name = "Ραβδί Αιθέρα",
                 description = "Μαγεμένο ραβδί με μπλε αύρα που επικαλείται στοιχειακή ενέργεια.",
                 icon = "weapon/rod.png",
                 rarity = Rarity.EPIC,
-                damage = 18,
-                element = "ARCANE",
-                attackSpeed = 1.1f
+                category = ItemCategory.WEAPONS,
+                subcategory = ItemSubcategory.ROD,
+                weaponStats = WeaponStats(damage = 18, element = "ARCANE", attackSpeed = 1.1f)
             )
 
-            HeroClass.PRIESTESS -> WeaponItem(
+            HeroClass.PRIESTESS -> InventoryItem(
                 id = "${'$'}prefix_weapon",
                 name = "Ραβδί Φωτεινών Ρούνων",
                 description = "Ιερό ραβδί με φωτεινά runes που ενισχύει τα ξόρκια θεραπείας.",
                 icon = "weapon/rod.png",
                 rarity = Rarity.RARE,
-                damage = 16,
-                element = "HOLY",
-                attackSpeed = 1.2f
+                category = ItemCategory.WEAPONS,
+                subcategory = ItemSubcategory.ROD,
+                weaponStats = WeaponStats(damage = 16, element = "HOLY", attackSpeed = 1.2f)
             )
         }
     }
@@ -172,7 +173,7 @@ private object DefaultEquipmentLoadout {
             icon = "armor/chest.png"
         )
 
-        ItemCategory.SHIELD -> baseItem(
+        ItemCategory.SHIELDS -> baseItem(
             prefix,
             category,
             name = "Φυλαχτό Άμυνας",
@@ -180,7 +181,7 @@ private object DefaultEquipmentLoadout {
             icon = "armor/helmet.png"
         )
 
-        ItemCategory.ACCESSORY -> baseItem(
+        ItemCategory.ACCESSORIES -> baseItem(
             prefix,
             category,
             name = "Φυλαχτό Ισορροπίας",
@@ -188,7 +189,7 @@ private object DefaultEquipmentLoadout {
             icon = "armor/gloves.png"
         )
 
-        ItemCategory.CONSUMABLE -> baseItem(
+        ItemCategory.CONSUMABLES -> baseItem(
             prefix,
             category,
             name = "Φίλτρο Ζωτικότητας",
@@ -196,7 +197,7 @@ private object DefaultEquipmentLoadout {
             icon = "inventory/backbag.png"
         )
 
-        ItemCategory.SPELL_SCROLL -> baseItem(
+        ItemCategory.SPELLS_SCROLLS -> baseItem(
             prefix,
             category,
             name = "Πάπυρος Σπινθήρα",
@@ -205,7 +206,7 @@ private object DefaultEquipmentLoadout {
             rarity = Rarity.RARE
         )
 
-        ItemCategory.RUNE_GEM -> baseItem(
+        ItemCategory.RUNES_GEMS -> baseItem(
             prefix,
             category,
             name = "Ρούνος Ενδυνάμωσης",
@@ -213,7 +214,7 @@ private object DefaultEquipmentLoadout {
             icon = "puzzle/circle.png"
         )
 
-        ItemCategory.CRAFTING_MATERIAL -> baseItem(
+        ItemCategory.CRAFTING_MATERIALS -> baseItem(
             prefix,
             category,
             name = "Δέμα Υλικών",
@@ -221,7 +222,7 @@ private object DefaultEquipmentLoadout {
             icon = "armor/chest-women_b.png"
         )
 
-        ItemCategory.QUEST_ITEM -> baseItem(
+        ItemCategory.QUEST_ITEMS -> baseItem(
             prefix,
             category,
             name = "Σύμβολο Αποστολής",
@@ -230,7 +231,7 @@ private object DefaultEquipmentLoadout {
             rarity = Rarity.RARE
         )
 
-        ItemCategory.CURRENCY -> baseItem(
+        ItemCategory.GOLD_CURRENCY -> baseItem(
             prefix,
             category,
             name = "Πουγκί Χρυσού",
@@ -238,7 +239,7 @@ private object DefaultEquipmentLoadout {
             icon = "inventory/inventory.png"
         )
 
-        ItemCategory.WEAPON -> null
+        ItemCategory.WEAPONS -> null
     }
 
     private fun baseItem(
@@ -247,16 +248,27 @@ private object DefaultEquipmentLoadout {
         name: String,
         description: String,
         icon: String,
-        rarity: Rarity = Rarity.COMMON
+        rarity: Rarity = Rarity.COMMON,
+        stackable: Boolean = category in STACKABLE_DEFAULTS,
+        quantity: Int = if (stackable) 5 else 1
     ): Item = InventoryItem(
         id = "${'$'}prefix_${'$'}{category.name.lowercase()}_01",
         name = name,
         description = description,
         icon = icon,
         rarity = rarity,
-        category = category
+        category = category,
+        stackable = stackable,
+        quantity = quantity
     )
 }
+
+private val STACKABLE_DEFAULTS = setOf(
+    ItemCategory.CONSUMABLES,
+    ItemCategory.RUNES_GEMS,
+    ItemCategory.CRAFTING_MATERIALS,
+    ItemCategory.GOLD_CURRENCY
+)
 
 private fun HeroProfile.toFirestoreMap(): Map<String, Any> = mapOf(
     "heroId" to hero.id,

--- a/app/src/main/java/com/example/runeboundmagic/codex/HeroCodexData.kt
+++ b/app/src/main/java/com/example/runeboundmagic/codex/HeroCodexData.kt
@@ -59,7 +59,7 @@ object HeroCodexData {
             description = "Κοντάρι με ενισχυμένη θεραπευτική αύρα. Damage: 32, Element: Light, Skill: Radiant Nova.",
             icon = "weapon/rod.png",
             rarity = Rarity.RARE,
-            category = ItemCategory.WEAPON
+            category = ItemCategory.WEAPONS
         )
 
         val armor = listOf(
@@ -104,7 +104,7 @@ object HeroCodexData {
                 description = "Μαγικό φράγμα με 35 Block.",
                 icon = "armor/helmet_b.png",
                 rarity = Rarity.EPIC,
-                category = ItemCategory.SHIELD
+                category = ItemCategory.SHIELDS
             )
         )
 
@@ -115,7 +115,7 @@ object HeroCodexData {
                 description = "Δαχτυλίδι που χαρίζει +15% Healing Power.",
                 icon = "armor/gloves_b.png",
                 rarity = Rarity.EPIC,
-                category = ItemCategory.ACCESSORY
+                category = ItemCategory.ACCESSORIES
             ),
             InventoryItem(
                 id = "starlit_belt",
@@ -123,7 +123,7 @@ object HeroCodexData {
                 description = "Ζώνη που αποθηκεύει 2 επιπλέον potions.",
                 icon = "armor/buttos_c.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.ACCESSORY
+                category = ItemCategory.ACCESSORIES
             )
         )
 
@@ -134,7 +134,7 @@ object HeroCodexData {
                 description = "Αποκαθιστά πλήρως την υγεία του συμμάχου.",
                 icon = "inventory/backbag.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.CONSUMABLE
+                category = ItemCategory.CONSUMABLES
             ),
             InventoryItem(
                 id = "clarity_draught",
@@ -142,7 +142,7 @@ object HeroCodexData {
                 description = "Προσωρινό +25 Mana και +10% Crit Chance.",
                 icon = "inventory/inventory.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.CONSUMABLE
+                category = ItemCategory.CONSUMABLES
             )
         )
 
@@ -153,7 +153,7 @@ object HeroCodexData {
                 description = "Κάλεσμα φωτεινής έκρηξης που καθαρίζει debuffs.",
                 icon = "characters/mystical_priestess.png",
                 rarity = Rarity.EPIC,
-                category = ItemCategory.SPELL_SCROLL
+                category = ItemCategory.SPELLS_SCROLLS
             )
         )
 
@@ -164,7 +164,7 @@ object HeroCodexData {
                 description = "Ρούνος που ενισχύει θεραπείες κατά +12%.",
                 icon = "puzzle/circle.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.RUNE_GEM
+                category = ItemCategory.RUNES_GEMS
             )
         )
 
@@ -175,7 +175,7 @@ object HeroCodexData {
                 description = "Υλικό craft για μυστικιστικές αναβαθμίσεις.",
                 icon = "armor/chest-women_b.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.CRAFTING_MATERIAL
+                category = ItemCategory.CRAFTING_MATERIALS
             )
         )
 
@@ -186,7 +186,7 @@ object HeroCodexData {
                 description = "Κομμάτι κρυστάλλου που ανοίγει αρχαίες πύλες.",
                 icon = "characters/black_mage.png",
                 rarity = Rarity.EPIC,
-                category = ItemCategory.QUEST_ITEM
+                category = ItemCategory.QUEST_ITEMS
             )
         )
 
@@ -197,21 +197,21 @@ object HeroCodexData {
                 description = "Περιέχει 150 χρυσά νομίσματα.",
                 icon = "inventory/inventory.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.CURRENCY
+                category = ItemCategory.GOLD_CURRENCY
             )
         )
 
         val heroItems = mapOf(
-            ItemCategory.WEAPON to listOf(rod),
+            ItemCategory.WEAPONS to listOf(rod),
             ItemCategory.ARMOR to armor,
-            ItemCategory.SHIELD to shield,
-            ItemCategory.ACCESSORY to accessories,
-            ItemCategory.CONSUMABLE to consumables,
-            ItemCategory.SPELL_SCROLL to spells,
-            ItemCategory.RUNE_GEM to runes,
-            ItemCategory.CRAFTING_MATERIAL to materials,
-            ItemCategory.QUEST_ITEM to questItems,
-            ItemCategory.CURRENCY to currency
+            ItemCategory.SHIELDS to shield,
+            ItemCategory.ACCESSORIES to accessories,
+            ItemCategory.CONSUMABLES to consumables,
+            ItemCategory.SPELLS_SCROLLS to spells,
+            ItemCategory.RUNES_GEMS to runes,
+            ItemCategory.CRAFTING_MATERIALS to materials,
+            ItemCategory.QUEST_ITEMS to questItems,
+            ItemCategory.GOLD_CURRENCY to currency
         )
 
         return HeroCodexProfile(
@@ -231,7 +231,7 @@ object HeroCodexData {
             description = "Damage: 40, Element: Arcane, Skill: Rune Surge.",
             icon = "weapon/mage_staff.png",
             rarity = Rarity.EPIC,
-            category = ItemCategory.WEAPON
+            category = ItemCategory.WEAPONS
         )
 
         val armor = listOf(
@@ -276,7 +276,7 @@ object HeroCodexData {
                 description = "Απορροφά 120 damage και επιβραδύνει εχθρούς.",
                 icon = "armor/helmet.png",
                 rarity = Rarity.EPIC,
-                category = ItemCategory.SHIELD
+                category = ItemCategory.SHIELDS
             )
         )
 
@@ -287,7 +287,7 @@ object HeroCodexData {
                 description = "+10% Spell Crit και +5 Mana Regen.",
                 icon = "armor/gloves.png",
                 rarity = Rarity.EPIC,
-                category = ItemCategory.ACCESSORY
+                category = ItemCategory.ACCESSORIES
             ),
             InventoryItem(
                 id = "mana_belt",
@@ -295,7 +295,7 @@ object HeroCodexData {
                 description = "Αποθηκεύει 3 επιπλέον scrolls.",
                 icon = "armor/buttos_c.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.ACCESSORY
+                category = ItemCategory.ACCESSORIES
             )
         )
 
@@ -306,7 +306,7 @@ object HeroCodexData {
                 description = "Επαναφέρει αμέσως 120 Mana.",
                 icon = "inventory/inventory.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.CONSUMABLE
+                category = ItemCategory.CONSUMABLES
             ),
             InventoryItem(
                 id = "spell_flux",
@@ -314,7 +314,7 @@ object HeroCodexData {
                 description = "Προσωρινό +20% Rune Damage.",
                 icon = "inventory/backbag.png",
                 rarity = Rarity.EPIC,
-                category = ItemCategory.CONSUMABLE
+                category = ItemCategory.CONSUMABLES
             )
         )
 
@@ -325,7 +325,7 @@ object HeroCodexData {
                 description = "Καλεί μετεωρίτες που κάνουν AoE damage.",
                 icon = "characters/mage.png",
                 rarity = Rarity.LEGENDARY,
-                category = ItemCategory.SPELL_SCROLL
+                category = ItemCategory.SPELLS_SCROLLS
             ),
             InventoryItem(
                 id = "ward_scroll",
@@ -333,7 +333,7 @@ object HeroCodexData {
                 description = "Δημιουργεί χρονικό πεδίο άμυνας.",
                 icon = "characters/mage.png",
                 rarity = Rarity.EPIC,
-                category = ItemCategory.SPELL_SCROLL
+                category = ItemCategory.SPELLS_SCROLLS
             )
         )
 
@@ -344,7 +344,7 @@ object HeroCodexData {
                 description = "+2 σε κάθε chain spell.",
                 icon = "puzzle/circle.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.RUNE_GEM
+                category = ItemCategory.RUNES_GEMS
             ),
             InventoryItem(
                 id = "prismatic_gem",
@@ -352,7 +352,7 @@ object HeroCodexData {
                 description = "Επιτρέπει αλλαγή στοιχείου στις μαγείες.",
                 icon = "armor/chest-women_b.png",
                 rarity = Rarity.EPIC,
-                category = ItemCategory.RUNE_GEM
+                category = ItemCategory.RUNES_GEMS
             )
         )
 
@@ -363,7 +363,7 @@ object HeroCodexData {
                 description = "Χρησιμοποιείται για crafting μπατών και ράβδων.",
                 icon = "armor/chest.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.CRAFTING_MATERIAL
+                category = ItemCategory.CRAFTING_MATERIALS
             )
         )
 
@@ -374,7 +374,7 @@ object HeroCodexData {
                 description = "Απαραίτητη για να ξεκλειδώσει το Rune Vault.",
                 icon = "characters/black_mage.png",
                 rarity = Rarity.EPIC,
-                category = ItemCategory.QUEST_ITEM
+                category = ItemCategory.QUEST_ITEMS
             )
         )
 
@@ -385,21 +385,21 @@ object HeroCodexData {
                 description = "Περιέχει 110 χρυσά νομίσματα και 5 arcane σφραγίδες.",
                 icon = "inventory/inventory.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.CURRENCY
+                category = ItemCategory.GOLD_CURRENCY
             )
         )
 
         val heroItems = mapOf(
-            ItemCategory.WEAPON to listOf(staff),
+            ItemCategory.WEAPONS to listOf(staff),
             ItemCategory.ARMOR to armor,
-            ItemCategory.SHIELD to shield,
-            ItemCategory.ACCESSORY to accessories,
-            ItemCategory.CONSUMABLE to consumables,
-            ItemCategory.SPELL_SCROLL to spells,
-            ItemCategory.RUNE_GEM to runes,
-            ItemCategory.CRAFTING_MATERIAL to materials,
-            ItemCategory.QUEST_ITEM to questItems,
-            ItemCategory.CURRENCY to currency
+            ItemCategory.SHIELDS to shield,
+            ItemCategory.ACCESSORIES to accessories,
+            ItemCategory.CONSUMABLES to consumables,
+            ItemCategory.SPELLS_SCROLLS to spells,
+            ItemCategory.RUNES_GEMS to runes,
+            ItemCategory.CRAFTING_MATERIALS to materials,
+            ItemCategory.QUEST_ITEMS to questItems,
+            ItemCategory.GOLD_CURRENCY to currency
         )
 
         return HeroCodexProfile(
@@ -419,7 +419,7 @@ object HeroCodexData {
             description = "Damage: 48, Element: Fire, Skill: Blazing Rift.",
             icon = "weapon/shord.png",
             rarity = Rarity.RARE,
-            category = ItemCategory.WEAPON
+            category = ItemCategory.WEAPONS
         )
 
         val armor = listOf(
@@ -464,7 +464,7 @@ object HeroCodexData {
                 description = "Απορροφά 160 damage και αντεπιτίθεται με φωτιά.",
                 icon = "armor/helmet_b.png",
                 rarity = Rarity.EPIC,
-                category = ItemCategory.SHIELD
+                category = ItemCategory.SHIELDS
             )
         )
 
@@ -475,7 +475,7 @@ object HeroCodexData {
                 description = "+10% Crit Damage.",
                 icon = "armor/gloves_b.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.ACCESSORY
+                category = ItemCategory.ACCESSORIES
             )
         )
 
@@ -486,7 +486,7 @@ object HeroCodexData {
                 description = "+25 Defense για 3 γύρους.",
                 icon = "inventory/backbag.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.CONSUMABLE
+                category = ItemCategory.CONSUMABLES
             ),
             InventoryItem(
                 id = "rage_draught",
@@ -494,7 +494,7 @@ object HeroCodexData {
                 description = "+30 Attack και lifesteal.",
                 icon = "inventory/inventory.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.CONSUMABLE
+                category = ItemCategory.CONSUMABLES
             )
         )
 
@@ -507,7 +507,7 @@ object HeroCodexData {
                 description = "Ενισχύει πυρίνες επιθέσεις κατά +10%.",
                 icon = "puzzle/circle.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.RUNE_GEM
+                category = ItemCategory.RUNES_GEMS
             )
         )
 
@@ -518,7 +518,7 @@ object HeroCodexData {
                 description = "Βασικό υλικό για αναβαθμίσεις όπλων.",
                 icon = "armor/chest_b.png",
                 rarity = Rarity.COMMON,
-                category = ItemCategory.CRAFTING_MATERIAL
+                category = ItemCategory.CRAFTING_MATERIALS
             )
         )
 
@@ -529,7 +529,7 @@ object HeroCodexData {
                 description = "Αναγκαίο για το storyline του Warrior.",
                 icon = "characters/warrior.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.QUEST_ITEM
+                category = ItemCategory.QUEST_ITEMS
             )
         )
 
@@ -540,21 +540,21 @@ object HeroCodexData {
                 description = "Περιέχει 95 χρυσά νομίσματα.",
                 icon = "inventory/inventory.png",
                 rarity = Rarity.COMMON,
-                category = ItemCategory.CURRENCY
+                category = ItemCategory.GOLD_CURRENCY
             )
         )
 
         val heroItems = mapOf(
-            ItemCategory.WEAPON to listOf(sword),
+            ItemCategory.WEAPONS to listOf(sword),
             ItemCategory.ARMOR to armor,
-            ItemCategory.SHIELD to shield,
-            ItemCategory.ACCESSORY to accessories,
-            ItemCategory.CONSUMABLE to consumables,
-            ItemCategory.SPELL_SCROLL to spells,
-            ItemCategory.RUNE_GEM to runes,
-            ItemCategory.CRAFTING_MATERIAL to materials,
-            ItemCategory.QUEST_ITEM to questItems,
-            ItemCategory.CURRENCY to currency
+            ItemCategory.SHIELDS to shield,
+            ItemCategory.ACCESSORIES to accessories,
+            ItemCategory.CONSUMABLES to consumables,
+            ItemCategory.SPELLS_SCROLLS to spells,
+            ItemCategory.RUNES_GEMS to runes,
+            ItemCategory.CRAFTING_MATERIALS to materials,
+            ItemCategory.QUEST_ITEMS to questItems,
+            ItemCategory.GOLD_CURRENCY to currency
         )
 
         return HeroCodexProfile(
@@ -574,7 +574,7 @@ object HeroCodexData {
             description = "Damage: 36, Element: Wind, Skill: Arrow Storm.",
             icon = "weapon/crossbow.png",
             rarity = Rarity.RARE,
-            category = ItemCategory.WEAPON
+            category = ItemCategory.WEAPONS
         )
 
         val armor = listOf(
@@ -621,7 +621,7 @@ object HeroCodexData {
                 description = "+5 βέλη ανά μάχη.",
                 icon = "armor/buttos_c.png",
                 rarity = Rarity.EPIC,
-                category = ItemCategory.ACCESSORY
+                category = ItemCategory.ACCESSORIES
             ),
             InventoryItem(
                 id = "ranger_ring",
@@ -629,7 +629,7 @@ object HeroCodexData {
                 description = "Ανίχνευση παγίδων σε μεγαλύτερη ακτίνα.",
                 icon = "armor/gloves_b.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.ACCESSORY
+                category = ItemCategory.ACCESSORIES
             )
         )
 
@@ -640,7 +640,7 @@ object HeroCodexData {
                 description = "+20 Evasion για 3 γύρους.",
                 icon = "inventory/inventory.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.CONSUMABLE
+                category = ItemCategory.CONSUMABLES
             )
         )
 
@@ -651,7 +651,7 @@ object HeroCodexData {
                 description = "Δένει τους εχθρούς με ρίζες.",
                 icon = "characters/ranger.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.SPELL_SCROLL
+                category = ItemCategory.SPELLS_SCROLLS
             )
         )
 
@@ -662,7 +662,7 @@ object HeroCodexData {
                 description = "+10% ταχύτητα βολής.",
                 icon = "puzzle/circle.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.RUNE_GEM
+                category = ItemCategory.RUNES_GEMS
             )
         )
 
@@ -673,7 +673,7 @@ object HeroCodexData {
                 description = "Crafting υλικό για βελτιωμένα βέλη.",
                 icon = "armor/chest-women_b.png",
                 rarity = Rarity.COMMON,
-                category = ItemCategory.CRAFTING_MATERIAL
+                category = ItemCategory.CRAFTING_MATERIALS
             )
         )
 
@@ -684,7 +684,7 @@ object HeroCodexData {
                 description = "Οδηγεί σε κρυφές περιοχές της αποστολής.",
                 icon = "characters/ranger.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.QUEST_ITEM
+                category = ItemCategory.QUEST_ITEMS
             )
         )
 
@@ -695,21 +695,21 @@ object HeroCodexData {
                 description = "Περιέχει 105 χρυσά νομίσματα.",
                 icon = "inventory/inventory.png",
                 rarity = Rarity.RARE,
-                category = ItemCategory.CURRENCY
+                category = ItemCategory.GOLD_CURRENCY
             )
         )
 
         val heroItems = mapOf(
-            ItemCategory.WEAPON to listOf(bow),
+            ItemCategory.WEAPONS to listOf(bow),
             ItemCategory.ARMOR to armor,
-            ItemCategory.SHIELD to shield,
-            ItemCategory.ACCESSORY to accessories,
-            ItemCategory.CONSUMABLE to consumables,
-            ItemCategory.SPELL_SCROLL to spells,
-            ItemCategory.RUNE_GEM to runes,
-            ItemCategory.CRAFTING_MATERIAL to materials,
-            ItemCategory.QUEST_ITEM to questItems,
-            ItemCategory.CURRENCY to currency
+            ItemCategory.SHIELDS to shield,
+            ItemCategory.ACCESSORIES to accessories,
+            ItemCategory.CONSUMABLES to consumables,
+            ItemCategory.SPELLS_SCROLLS to spells,
+            ItemCategory.RUNES_GEMS to runes,
+            ItemCategory.CRAFTING_MATERIALS to materials,
+            ItemCategory.QUEST_ITEMS to questItems,
+            ItemCategory.GOLD_CURRENCY to currency
         )
 
         return HeroCodexProfile(
@@ -735,55 +735,55 @@ object HeroCodexData {
     }
 
     private val CATEGORY_ORDER = listOf(
-        ItemCategory.WEAPON,
+        ItemCategory.WEAPONS,
         ItemCategory.ARMOR,
-        ItemCategory.SHIELD,
-        ItemCategory.ACCESSORY,
-        ItemCategory.CONSUMABLE,
-        ItemCategory.SPELL_SCROLL,
-        ItemCategory.RUNE_GEM,
-        ItemCategory.CRAFTING_MATERIAL,
-        ItemCategory.QUEST_ITEM,
-        ItemCategory.CURRENCY
+        ItemCategory.SHIELDS,
+        ItemCategory.ACCESSORIES,
+        ItemCategory.CONSUMABLES,
+        ItemCategory.SPELLS_SCROLLS,
+        ItemCategory.RUNES_GEMS,
+        ItemCategory.CRAFTING_MATERIALS,
+        ItemCategory.QUEST_ITEMS,
+        ItemCategory.GOLD_CURRENCY
     )
 
     private val CATEGORY_TITLES = mapOf(
-        ItemCategory.WEAPON to "Όπλα",
+        ItemCategory.WEAPONS to "Όπλα",
         ItemCategory.ARMOR to "Πανοπλία",
-        ItemCategory.SHIELD to "Ασπίδες",
-        ItemCategory.ACCESSORY to "Αξεσουάρ",
-        ItemCategory.CONSUMABLE to "Καταναλώσιμα",
-        ItemCategory.SPELL_SCROLL to "Μαγείες & Πάπυροι",
-        ItemCategory.RUNE_GEM to "Ρούνες & Πολύτιμοι Λίθοι",
-        ItemCategory.CRAFTING_MATERIAL to "Υλικά Crafting",
-        ItemCategory.QUEST_ITEM to "Αντικείμενα Αποστολών",
-        ItemCategory.CURRENCY to "Χρυσός & Νομίσματα"
+        ItemCategory.SHIELDS to "Ασπίδες",
+        ItemCategory.ACCESSORIES to "Αξεσουάρ",
+        ItemCategory.CONSUMABLES to "Καταναλώσιμα",
+        ItemCategory.SPELLS_SCROLLS to "Μαγείες & Πάπυροι",
+        ItemCategory.RUNES_GEMS to "Ρούνες & Πολύτιμοι Λίθοι",
+        ItemCategory.CRAFTING_MATERIALS to "Υλικά Crafting",
+        ItemCategory.QUEST_ITEMS to "Αντικείμενα Αποστολών",
+        ItemCategory.GOLD_CURRENCY to "Χρυσός & Νομίσματα"
     )
 
     private val CATEGORY_DESCRIPTIONS = mapOf(
-        ItemCategory.WEAPON to "Όλα τα επιθετικά εργαλεία και τα ειδικά όπλα του ήρωα.",
+        ItemCategory.WEAPONS to "Όλα τα επιθετικά εργαλεία και τα ειδικά όπλα του ήρωα.",
         ItemCategory.ARMOR to "Πανοπλίες και ενισχύσεις για κάθε slot.",
-        ItemCategory.SHIELD to "Ασπίδες και μαγικά φράγματα για άμυνα.",
-        ItemCategory.ACCESSORY to "Δαχτυλίδια, φυλαχτά και ζώνες με buffs.",
-        ItemCategory.CONSUMABLE to "Φίλτρα ζωής, mana και προσωρινές ενισχύσεις.",
-        ItemCategory.SPELL_SCROLL to "Ξεχωριστές μαγείες ή πάπυροι προς χρήση στη μάχη.",
-        ItemCategory.RUNE_GEM to "Ρούνες και πολύτιμοι λίθοι για enchantments.",
-        ItemCategory.CRAFTING_MATERIAL to "Υλικά crafting όπως ores, herbs και essences.",
-        ItemCategory.QUEST_ITEM to "Ειδικά αντικείμενα για αποστολές.",
-        ItemCategory.CURRENCY to "Χρυσά νομίσματα και λοιπά νομίσματα." 
+        ItemCategory.SHIELDS to "Ασπίδες και μαγικά φράγματα για άμυνα.",
+        ItemCategory.ACCESSORIES to "Δαχτυλίδια, φυλαχτά και ζώνες με buffs.",
+        ItemCategory.CONSUMABLES to "Φίλτρα ζωής, mana και προσωρινές ενισχύσεις.",
+        ItemCategory.SPELLS_SCROLLS to "Ξεχωριστές μαγείες ή πάπυροι προς χρήση στη μάχη.",
+        ItemCategory.RUNES_GEMS to "Ρούνες και πολύτιμοι λίθοι για enchantments.",
+        ItemCategory.CRAFTING_MATERIALS to "Υλικά crafting όπως ores, herbs και essences.",
+        ItemCategory.QUEST_ITEMS to "Ειδικά αντικείμενα για αποστολές.",
+        ItemCategory.GOLD_CURRENCY to "Χρυσά νομίσματα και λοιπά νομίσματα." 
     )
 
     private val CATEGORY_ICONS = mapOf(
-        ItemCategory.WEAPON to "weapon/rod.png",
+        ItemCategory.WEAPONS to "weapon/rod.png",
         ItemCategory.ARMOR to "armor/chest.png",
-        ItemCategory.SHIELD to "armor/helmet.png",
-        ItemCategory.ACCESSORY to "armor/gloves.png",
-        ItemCategory.CONSUMABLE to "inventory/inventory.png",
-        ItemCategory.SPELL_SCROLL to "characters/mage.png",
-        ItemCategory.RUNE_GEM to "puzzle/circle.png",
-        ItemCategory.CRAFTING_MATERIAL to "armor/chest-women_b.png",
-        ItemCategory.QUEST_ITEM to "inventory/backbag.png",
-        ItemCategory.CURRENCY to "inventory/inventory.png"
+        ItemCategory.SHIELDS to "armor/helmet.png",
+        ItemCategory.ACCESSORIES to "armor/gloves.png",
+        ItemCategory.CONSUMABLES to "inventory/inventory.png",
+        ItemCategory.SPELLS_SCROLLS to "characters/mage.png",
+        ItemCategory.RUNES_GEMS to "puzzle/circle.png",
+        ItemCategory.CRAFTING_MATERIALS to "armor/chest-women_b.png",
+        ItemCategory.QUEST_ITEMS to "inventory/backbag.png",
+        ItemCategory.GOLD_CURRENCY to "inventory/inventory.png"
     )
 }
 

--- a/app/src/main/java/com/example/runeboundmagic/codex/HeroProfile.kt
+++ b/app/src/main/java/com/example/runeboundmagic/codex/HeroProfile.kt
@@ -7,9 +7,9 @@ import com.example.runeboundmagic.data.codex.local.CodexInventoryWithItems
 import com.example.runeboundmagic.data.codex.local.HeroWithInventory
 import com.example.runeboundmagic.heroes.Hero
 import com.example.runeboundmagic.inventory.Inventory
-import com.example.runeboundmagic.inventory.InventoryItem
 import com.example.runeboundmagic.inventory.Item
-import com.example.runeboundmagic.inventory.WeaponItem
+import com.example.runeboundmagic.inventory.InventoryItem
+import com.example.runeboundmagic.inventory.WeaponStats
 
 data class HeroProfile(
     val hero: Hero,
@@ -55,31 +55,32 @@ fun HeroWithInventory.toDomain(): HeroProfile {
 
 private fun CodexInventoryWithItems.toDomainInventory(hero: Hero): Inventory {
     val items = items.map { entity ->
-        if (entity.category == com.example.runeboundmagic.inventory.ItemCategory.WEAPON &&
+        val stats = if (
             entity.damage != null &&
             entity.attackSpeed != null &&
             entity.element != null
         ) {
-            WeaponItem(
-                id = entity.itemId,
-                name = entity.name,
-                description = entity.description,
-                icon = entity.icon,
-                rarity = entity.rarity,
+            WeaponStats(
                 damage = entity.damage,
                 element = entity.element,
                 attackSpeed = entity.attackSpeed
             )
         } else {
-            InventoryItem(
-                id = entity.itemId,
-                name = entity.name,
-                description = entity.description,
-                icon = entity.icon,
-                rarity = entity.rarity,
-                category = entity.category
-            )
+            null
         }
+        InventoryItem(
+            id = entity.itemId,
+            name = entity.name,
+            description = entity.description,
+            icon = entity.icon,
+            rarity = entity.rarity,
+            category = entity.category,
+            subcategory = entity.subcategory,
+            stackable = entity.stackable,
+            quantity = entity.quantity,
+            allowedSlots = entity.allowedSlots,
+            weaponStats = stats
+        )
     }
     return Inventory(
         id = inventory.inventoryId,
@@ -90,40 +91,20 @@ private fun CodexInventoryWithItems.toDomainInventory(hero: Hero): Inventory {
     )
 }
 
-private fun Item.toEntity(inventoryId: String): CodexInventoryItemEntity = when (this) {
-    is WeaponItem -> CodexInventoryItemEntity(
-        inventoryId = inventoryId,
-        itemId = id,
-        name = name,
-        description = description,
-        icon = icon,
-        rarity = rarity,
-        category = category,
-        rarityId = rarity.name,
-        damage = damage,
-        element = element,
-        attackSpeed = attackSpeed
-    )
-
-    is InventoryItem -> CodexInventoryItemEntity(
-        inventoryId = inventoryId,
-        itemId = id,
-        name = name,
-        description = description,
-        icon = icon,
-        rarity = rarity,
-        category = category,
-        rarityId = rarity.name
-    )
-
-    else -> CodexInventoryItemEntity(
-        inventoryId = inventoryId,
-        itemId = id,
-        name = name,
-        description = description,
-        icon = icon,
-        rarity = rarity,
-        category = category,
-        rarityId = rarity.name
-    )
-}
+private fun Item.toEntity(inventoryId: String): CodexInventoryItemEntity = CodexInventoryItemEntity(
+    inventoryId = inventoryId,
+    itemId = id,
+    name = name,
+    description = description,
+    icon = icon,
+    rarity = rarity,
+    category = category,
+    subcategory = subcategory,
+    stackable = stackable,
+    quantity = quantity,
+    allowedSlots = allowedSlots,
+    rarityId = rarity.name,
+    damage = weaponStats?.damage,
+    element = weaponStats?.element,
+    attackSpeed = weaponStats?.attackSpeed
+)

--- a/app/src/main/java/com/example/runeboundmagic/data/codex/local/CodexDatabase.kt
+++ b/app/src/main/java/com/example/runeboundmagic/data/codex/local/CodexDatabase.kt
@@ -16,7 +16,7 @@ import androidx.room.TypeConverters
         ItemCategoryEntity::class,
         HeroCardEntity::class
     ],
-    version = 2,
+    version = 3,
     exportSchema = false
 )
 @TypeConverters(CodexTypeConverters::class)

--- a/app/src/main/java/com/example/runeboundmagic/data/codex/local/CodexEntities.kt
+++ b/app/src/main/java/com/example/runeboundmagic/data/codex/local/CodexEntities.kt
@@ -7,7 +7,9 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import androidx.room.Relation
 import com.example.runeboundmagic.heroes.HeroClass
+import com.example.runeboundmagic.inventory.EquipmentSlot
 import com.example.runeboundmagic.inventory.ItemCategory
+import com.example.runeboundmagic.inventory.ItemSubcategory
 import com.example.runeboundmagic.inventory.Rarity
 
 @Entity(tableName = "codex_heroes")
@@ -125,6 +127,10 @@ data class CodexInventoryItemEntity(
     val icon: String,
     val rarity: Rarity,
     val category: ItemCategory,
+    val subcategory: ItemSubcategory? = null,
+    val stackable: Boolean = false,
+    val quantity: Int = 1,
+    val allowedSlots: List<EquipmentSlot> = emptyList(),
     val rarityId: String,
     val damage: Int? = null,
     val element: String? = null,

--- a/app/src/main/java/com/example/runeboundmagic/data/codex/local/CodexTypeConverters.kt
+++ b/app/src/main/java/com/example/runeboundmagic/data/codex/local/CodexTypeConverters.kt
@@ -2,7 +2,9 @@ package com.example.runeboundmagic.data.codex.local
 
 import androidx.room.TypeConverter
 import com.example.runeboundmagic.heroes.HeroClass
+import com.example.runeboundmagic.inventory.EquipmentSlot
 import com.example.runeboundmagic.inventory.ItemCategory
+import com.example.runeboundmagic.inventory.ItemSubcategory
 import com.example.runeboundmagic.inventory.Rarity
 
 class CodexTypeConverters {
@@ -20,7 +22,28 @@ class CodexTypeConverters {
     @TypeConverter
     fun toItemCategory(value: String): ItemCategory = runCatching {
         ItemCategory.valueOf(value)
-    }.getOrDefault(ItemCategory.WEAPON)
+    }.getOrDefault(ItemCategory.WEAPONS)
+
+    @TypeConverter
+    fun fromItemSubcategory(subcategory: ItemSubcategory?): String? = subcategory?.name
+
+    @TypeConverter
+    fun toItemSubcategory(value: String?): ItemSubcategory? = value
+        ?.takeIf { it.isNotBlank() }
+        ?.let { runCatching { ItemSubcategory.valueOf(it) }.getOrNull() }
+
+    @TypeConverter
+    fun fromEquipmentSlots(slots: List<EquipmentSlot>): String = slots.joinToString(separator = ",") { it.name }
+
+    @TypeConverter
+    fun toEquipmentSlots(value: String): List<EquipmentSlot> = value
+        .takeIf { it.isNotBlank() }
+        ?.split(",")
+        ?.mapNotNull { token ->
+            token.trim().takeIf { it.isNotEmpty() }
+                ?.let { runCatching { EquipmentSlot.valueOf(it) }.getOrNull() }
+        }
+        ?: emptyList()
 
     @TypeConverter
     fun fromRarity(rarity: Rarity): String = rarity.name

--- a/app/src/main/java/com/example/runeboundmagic/inventory/EquipmentSlot.kt
+++ b/app/src/main/java/com/example/runeboundmagic/inventory/EquipmentSlot.kt
@@ -1,0 +1,18 @@
+package com.example.runeboundmagic.inventory
+
+/**
+ * Διαθέσιμα slots εξοπλισμού για τους ήρωες.
+ */
+enum class EquipmentSlot {
+    MAIN_HAND,
+    OFF_HAND,
+    HEAD,
+    CHEST,
+    HANDS,
+    FEET,
+    CLOAK,
+    RING1,
+    RING2,
+    AMULET,
+    BELT
+}

--- a/app/src/main/java/com/example/runeboundmagic/inventory/InventoryItem.kt
+++ b/app/src/main/java/com/example/runeboundmagic/inventory/InventoryItem.kt
@@ -1,0 +1,135 @@
+package com.example.runeboundmagic.inventory
+
+typealias InventoryItem = Item
+
+fun InventoryItem(
+    id: String,
+    name: String,
+    description: String,
+    icon: String,
+    rarity: Rarity,
+    category: ItemCategory,
+    subcategory: ItemSubcategory? = null,
+    stackable: Boolean = false,
+    quantity: Int = 1,
+    allowedSlots: List<EquipmentSlot>? = null,
+    weaponStats: WeaponStats? = null
+): InventoryItem {
+    val resolvedSubcategory = subcategory ?: inferSubcategory(category, icon, name)
+    val resolvedSlots = allowedSlots ?: defaultSlots(category, resolvedSubcategory)
+    val sanitizedStackable = if (stackable) {
+        require(category in STACKABLE_CATEGORIES) {
+            "Η κατηγορία $category δεν επιτρέπει stackable αντικείμενα"
+        }
+        true
+    } else {
+        false
+    }
+    val sanitizedQuantity = if (sanitizedStackable) quantity.coerceAtLeast(1) else 1
+    return Item(
+        id = id,
+        name = name,
+        description = description,
+        iconPath = icon,
+        category = category,
+        subcategory = resolvedSubcategory,
+        rarity = rarity,
+        stackable = sanitizedStackable,
+        quantity = sanitizedQuantity,
+        allowedSlots = resolvedSlots,
+        weaponStats = weaponStats
+    )
+}
+
+private val STACKABLE_CATEGORIES = setOf(
+    ItemCategory.CONSUMABLES,
+    ItemCategory.RUNES_GEMS,
+    ItemCategory.CRAFTING_MATERIALS,
+    ItemCategory.GOLD_CURRENCY
+)
+
+private fun inferSubcategory(category: ItemCategory, icon: String, name: String): ItemSubcategory? {
+    val normalizedIcon = icon.lowercase()
+    val normalizedName = name.lowercase()
+    return when (category) {
+        ItemCategory.WEAPONS -> when {
+            "crossbow" in normalizedIcon || "crossbow" in normalizedName -> ItemSubcategory.CROSSBOW
+            "rod" in normalizedIcon || "rod" in normalizedName -> ItemSubcategory.ROD
+            "staff" in normalizedIcon || "staff" in normalizedName -> ItemSubcategory.STAFF
+            "dagger" in normalizedIcon || "dagger" in normalizedName -> ItemSubcategory.DAGGER
+            "axe" in normalizedIcon || "axe" in normalizedName -> ItemSubcategory.AXE
+            "bow" in normalizedIcon || "bow" in normalizedName -> ItemSubcategory.BOW
+            else -> ItemSubcategory.SWORD
+        }
+        ItemCategory.ARMOR -> when {
+            "helm" in normalizedIcon || "helmet" in normalizedName -> ItemSubcategory.HELMET
+            "glove" in normalizedIcon || "glove" in normalizedName -> ItemSubcategory.GLOVES
+            "boot" in normalizedIcon || "boot" in normalizedName -> ItemSubcategory.BOOTS
+            "cloak" in normalizedIcon || "cloak" in normalizedName -> ItemSubcategory.CLOAK
+            "robe" in normalizedIcon || "robe" in normalizedName -> ItemSubcategory.ROBES
+            "shirt" in normalizedIcon || "shirt" in normalizedName -> ItemSubcategory.SHIRT
+            else -> ItemSubcategory.CHEST
+        }
+        ItemCategory.SHIELDS -> when {
+            "buckler" in normalizedName -> ItemSubcategory.BUCKLER
+            "tower" in normalizedName -> ItemSubcategory.TOWER
+            else -> ItemSubcategory.MAGIC_BARRIER
+        }
+        ItemCategory.ACCESSORIES -> when {
+            "ring" in normalizedName -> ItemSubcategory.RING
+            "amulet" in normalizedName || "talisman" in normalizedName -> ItemSubcategory.AMULET
+            "belt" in normalizedName -> ItemSubcategory.BELT
+            else -> ItemSubcategory.CHARM
+        }
+        ItemCategory.CONSUMABLES -> when {
+            "mana" in normalizedName -> ItemSubcategory.POTION_MANA
+            "potion" in normalizedName -> ItemSubcategory.POTION_HEALTH
+            "elixir" in normalizedName -> ItemSubcategory.ELIXIR
+            else -> ItemSubcategory.FOOD
+        }
+        ItemCategory.SPELLS_SCROLLS -> if ("scroll" in normalizedName) ItemSubcategory.SCROLL else ItemSubcategory.SPELL
+        ItemCategory.RUNES_GEMS -> if ("gem" in normalizedName) ItemSubcategory.GEM else ItemSubcategory.RUNE
+        ItemCategory.CRAFTING_MATERIALS -> when {
+            "ore" in normalizedName -> ItemSubcategory.ORE
+            "herb" in normalizedName -> ItemSubcategory.HERB
+            "leather" in normalizedName -> ItemSubcategory.LEATHER
+            "wood" in normalizedName -> ItemSubcategory.WOOD
+            else -> ItemSubcategory.ESSENCE
+        }
+        ItemCategory.QUEST_ITEMS -> when {
+            "key" in normalizedName -> ItemSubcategory.KEY
+            "map" in normalizedName -> ItemSubcategory.MAP
+            else -> ItemSubcategory.ARTIFACT
+        }
+        ItemCategory.GOLD_CURRENCY -> when {
+            "token" in normalizedName -> ItemSubcategory.TOKEN
+            "shard" in normalizedName -> ItemSubcategory.SHARD
+            else -> ItemSubcategory.GOLD
+        }
+    }
+}
+
+private fun defaultSlots(
+    category: ItemCategory,
+    subcategory: ItemSubcategory?
+): List<EquipmentSlot> = when (category) {
+    ItemCategory.WEAPONS -> when (subcategory) {
+        ItemSubcategory.DAGGER -> listOf(EquipmentSlot.MAIN_HAND, EquipmentSlot.OFF_HAND)
+        else -> listOf(EquipmentSlot.MAIN_HAND)
+    }
+    ItemCategory.ARMOR -> when (subcategory) {
+        ItemSubcategory.HELMET -> listOf(EquipmentSlot.HEAD)
+        ItemSubcategory.GLOVES -> listOf(EquipmentSlot.HANDS)
+        ItemSubcategory.BOOTS -> listOf(EquipmentSlot.FEET)
+        ItemSubcategory.CLOAK -> listOf(EquipmentSlot.CLOAK)
+        else -> listOf(EquipmentSlot.CHEST)
+    }
+    ItemCategory.SHIELDS -> listOf(EquipmentSlot.OFF_HAND)
+    ItemCategory.ACCESSORIES -> when (subcategory) {
+        ItemSubcategory.RING -> listOf(EquipmentSlot.RING1, EquipmentSlot.RING2)
+        ItemSubcategory.AMULET, ItemSubcategory.CHARM -> listOf(EquipmentSlot.AMULET)
+        ItemSubcategory.BELT -> listOf(EquipmentSlot.BELT)
+        else -> emptyList()
+    }
+    else -> emptyList()
+}

--- a/app/src/main/java/com/example/runeboundmagic/inventory/Item.kt
+++ b/app/src/main/java/com/example/runeboundmagic/inventory/Item.kt
@@ -1,99 +1,200 @@
 package com.example.runeboundmagic.inventory
 
-/**
- * Αφηρημένος τύπος που περιγράφει ένα αντικείμενο του Codex.
- * Παρέχεται κλάση υλοποίησης [InventoryItem] για τις πιο συχνές περιπτώσεις.
- */
-abstract class Item {
-    abstract val id: String
-    abstract val name: String
-    abstract val description: String
-    abstract val icon: String
-    abstract val rarity: Rarity
-    abstract val category: ItemCategory
+import kotlin.math.max
 
-    open fun toFirestoreMap(): Map<String, Any> = mapOf(
-        "id" to id,
-        "name" to name,
-        "description" to description,
-        "icon" to icon,
-        "rarity" to rarity.name,
-        "category" to category.name
-    )
+/**
+ * Περιγράφει ένα αντικείμενο του inventory με αυστηρή κατηγοριοποίηση.
+ */
+data class Item(
+    val id: String,
+    val name: String,
+    val description: String = "",
+    val iconPath: String,
+    val category: ItemCategory,
+    val subcategory: ItemSubcategory? = null,
+    val rarity: Rarity = Rarity.COMMON,
+    val stackable: Boolean = false,
+    val quantity: Int = 1,
+    val allowedSlots: List<EquipmentSlot> = emptyList(),
+    val weaponStats: WeaponStats? = null
+) {
+
+    init {
+        require(id.isNotBlank()) { "Item id δεν μπορεί να είναι κενό" }
+        require(name.isNotBlank()) { "Item name δεν μπορεί να είναι κενό" }
+        if (category.requiresIcon()) {
+            require(iconPath.isNotBlank()) { "Icon path είναι υποχρεωτικό για την κατηγορία $category" }
+        }
+        if (subcategory != null) {
+            require(subcategory.parent == category) {
+                "Η υποκατηγορία $subcategory δεν ανήκει στην κατηγορία $category"
+            }
+        }
+        if (stackable) {
+            require(category in STACKABLE_CATEGORIES) {
+                "Μόνο οι κατηγορίες $STACKABLE_CATEGORIES μπορούν να κάνουν stack"
+            }
+            require(quantity > 0) { "Το quantity πρέπει να είναι θετικό" }
+        }
+        if (!stackable) {
+            require(quantity == 1) { "Τα μη stackable αντικείμενα πρέπει να έχουν quantity = 1" }
+        }
+        validateAllowedSlots()
+        if (weaponStats != null) {
+            require(category == ItemCategory.WEAPONS) { "Τα weaponStats επιτρέπονται μόνο σε weapons" }
+        }
+    }
+
+    private fun validateAllowedSlots() {
+        if (allowedSlots.isEmpty()) {
+            require(category !in EQUIPPABLE_CATEGORIES) {
+                "Η κατηγορία $category απαιτεί τουλάχιστον ένα equipment slot"
+            }
+            return
+        }
+        when (category) {
+            ItemCategory.WEAPONS -> require(allowedSlots.all { it == EquipmentSlot.MAIN_HAND || it == EquipmentSlot.OFF_HAND }) {
+                "Όπλα μπορούν να τοποθετηθούν μόνο σε main/off hand"
+            }
+            ItemCategory.ARMOR -> require(allowedSlots.all { it in ARMOR_SLOTS }) {
+                "Η πανοπλία πρέπει να αντιστοιχεί σε έγκυρο armor slot"
+            }
+            ItemCategory.SHIELDS -> require(allowedSlots == listOf(EquipmentSlot.OFF_HAND)) {
+                "Οι ασπίδες επιτρέπονται μόνο στο off hand"
+            }
+            ItemCategory.ACCESSORIES -> require(allowedSlots.all { it in ACCESSORY_SLOTS }) {
+                "Τα αξεσουάρ μπαίνουν μόνο σε accessory slots"
+            }
+            else -> require(allowedSlots.isEmpty()) {
+                "Η κατηγορία $category δεν υποστηρίζει equipment slots"
+            }
+        }
+    }
+
+    fun toFirestoreMap(): Map<String, Any> = buildMap {
+        put("id", id)
+        put("name", name)
+        put("description", description)
+        put("iconPath", iconPath)
+        put("category", category.name)
+        subcategory?.let { put("subcategory", it.name) }
+        put("rarity", rarity.name)
+        put("stackable", stackable)
+        put("quantity", quantity)
+        if (allowedSlots.isNotEmpty()) {
+            put("allowedSlots", allowedSlots.map(EquipmentSlot::name))
+        }
+        weaponStats?.let { stats ->
+            put("weaponStats", mapOf(
+                "damage" to stats.damage,
+                "element" to stats.element,
+                "attackSpeed" to stats.attackSpeed
+            ))
+        }
+    }
 
     companion object {
-        fun fromFirestore(data: Map<String, Any?>): Item? {
-            val id = data["id"]?.toString()?.takeIf { it.isNotBlank() } ?: return null
-            val name = data["name"]?.toString().orEmpty()
+        private val STACKABLE_CATEGORIES = setOf(
+            ItemCategory.CONSUMABLES,
+            ItemCategory.RUNES_GEMS,
+            ItemCategory.CRAFTING_MATERIALS,
+            ItemCategory.GOLD_CURRENCY
+        )
+        private val EQUIPPABLE_CATEGORIES = setOf(
+            ItemCategory.WEAPONS,
+            ItemCategory.ARMOR,
+            ItemCategory.SHIELDS,
+            ItemCategory.ACCESSORIES
+        )
+        private val ARMOR_SLOTS = setOf(
+            EquipmentSlot.HEAD,
+            EquipmentSlot.CHEST,
+            EquipmentSlot.HANDS,
+            EquipmentSlot.FEET,
+            EquipmentSlot.CLOAK
+        )
+        private val ACCESSORY_SLOTS = setOf(
+            EquipmentSlot.RING1,
+            EquipmentSlot.RING2,
+            EquipmentSlot.AMULET,
+            EquipmentSlot.BELT
+        )
+
+        fun fromFirestore(data: Map<String, Any?>): Item {
+            val id = data["id"]?.toString()?.takeIf { it.isNotBlank() }
+                ?: error("ITEM_ID_MISSING")
+            val name = data["name"]?.toString()?.ifBlank { null }
+                ?: error("ITEM_NAME_MISSING")
+            val categoryName = data["category"]?.toString()?.uppercase()
+                ?: error("ITEM_CATEGORY_MISSING")
+            val category = runCatching { ItemCategory.valueOf(categoryName) }
+                .getOrElse { error("ITEM_CATEGORY_INVALID") }
+            val iconPath = data["iconPath"]?.toString().orEmpty()
             val description = data["description"]?.toString().orEmpty()
-            val icon = data["icon"]?.toString().orEmpty()
             val rarityName = data["rarity"]?.toString()?.uppercase() ?: Rarity.COMMON.name
-            val categoryName = data["category"]?.toString()?.uppercase() ?: ItemCategory.WEAPON.name
             val rarity = runCatching { Rarity.valueOf(rarityName) }.getOrDefault(Rarity.COMMON)
-            val category = runCatching { ItemCategory.valueOf(categoryName) }.getOrDefault(ItemCategory.WEAPON)
-            val damage = (data["damage"] as? Number)?.toInt()
-            val attackSpeed = (data["attackSpeed"] as? Number)?.toDouble()?.toFloat()
-            val element = data["element"]?.toString()
-            return if (category == ItemCategory.WEAPON && damage != null && attackSpeed != null && element != null) {
-                WeaponItem(
-                    id = id,
-                    name = name,
-                    description = description,
-                    icon = icon,
-                    rarity = rarity,
-                    damage = damage,
-                    element = element,
-                    attackSpeed = attackSpeed
-                )
-            } else {
-                InventoryItem(
-                    id = id,
-                    name = name,
-                    description = description,
-                    icon = icon,
-                    rarity = rarity,
-                    category = category
-                )
+            val subcategory = data["subcategory"]?.toString()?.uppercase()?.let { value ->
+                runCatching { ItemSubcategory.valueOf(value) }
+                    .getOrNull()
             }
+            val stackable = data["stackable"] as? Boolean ?: false
+            val quantity = (data["quantity"] as? Number)?.toInt() ?: 1
+            val slotNames = (data["allowedSlots"] as? List<*>)
+                ?.mapNotNull { element ->
+                    (element as? String)
+                        ?.uppercase()
+                        ?.let { runCatching { EquipmentSlot.valueOf(it) }.getOrNull() }
+                }
+                ?: emptyList()
+            val weaponStats = (data["weaponStats"] as? Map<*, *>)?.let { map ->
+                val damage = (map["damage"] as? Number)?.toInt()
+                val element = map["element"]?.toString()
+                val attackSpeed = (map["attackSpeed"] as? Number)?.toFloat()
+                if (damage != null && element != null && attackSpeed != null) {
+                    WeaponStats(damage = damage, element = element, attackSpeed = attackSpeed)
+                } else {
+                    null
+                }
+            }
+
+            return Item(
+                id = id,
+                name = name,
+                description = description,
+                iconPath = iconPath,
+                category = category,
+                subcategory = subcategory,
+                rarity = rarity,
+                stackable = stackable,
+                quantity = max(1, quantity),
+                allowedSlots = slotNames,
+                weaponStats = weaponStats
+            )
         }
     }
 }
 
 /**
- * Απλή υλοποίηση αντικειμένου inventory.
+ * Πληροφορίες επιπλέον για όπλα.
  */
-data class InventoryItem(
-    override val id: String,
-    override val name: String,
-    override val description: String,
-    override val icon: String,
-    override val rarity: Rarity,
-    override val category: ItemCategory
-) : Item() {
-    override fun toFirestoreMap(): Map<String, Any> = super.toFirestoreMap() + ("type" to "ITEM")
-}
-
-/**
- * Εξειδικευμένο όπλο με πρόσθετες ιδιότητες για τη μάχη.
- */
-data class WeaponItem(
-    override val id: String,
-    override val name: String,
-    override val description: String,
-    override val icon: String,
-    override val rarity: Rarity,
+data class WeaponStats(
     val damage: Int,
     val element: String,
     val attackSpeed: Float
-) : Item() {
-    override val category: ItemCategory = ItemCategory.WEAPON
+)
 
-    override fun toFirestoreMap(): Map<String, Any> = super.toFirestoreMap() + mapOf(
-        "type" to "WEAPON",
-        "damage" to damage,
-        "element" to element,
-        "attackSpeed" to attackSpeed
-    )
+private fun ItemCategory.requiresIcon(): Boolean = when (this) {
+    ItemCategory.WEAPONS,
+    ItemCategory.ARMOR,
+    ItemCategory.SHIELDS,
+    ItemCategory.ACCESSORIES,
+    ItemCategory.CONSUMABLES,
+    ItemCategory.SPELLS_SCROLLS -> true
+
+    ItemCategory.RUNES_GEMS,
+    ItemCategory.CRAFTING_MATERIALS,
+    ItemCategory.QUEST_ITEMS,
+    ItemCategory.GOLD_CURRENCY -> false
 }
 
 /**
@@ -105,3 +206,6 @@ enum class Rarity {
     EPIC,
     LEGENDARY
 }
+
+val Item.icon: String
+    get() = iconPath

--- a/app/src/main/java/com/example/runeboundmagic/inventory/ItemCategory.kt
+++ b/app/src/main/java/com/example/runeboundmagic/inventory/ItemCategory.kt
@@ -4,14 +4,14 @@ package com.example.runeboundmagic.inventory
  * Όλες οι κατηγορίες αντικειμένων που υποστηρίζει το inventory.
  */
 enum class ItemCategory {
-    WEAPON,
+    WEAPONS,
     ARMOR,
-    SHIELD,
-    ACCESSORY,
-    CONSUMABLE,
-    SPELL_SCROLL,
-    RUNE_GEM,
-    CRAFTING_MATERIAL,
-    QUEST_ITEM,
-    CURRENCY
+    SHIELDS,
+    ACCESSORIES,
+    CONSUMABLES,
+    SPELLS_SCROLLS,
+    RUNES_GEMS,
+    CRAFTING_MATERIALS,
+    QUEST_ITEMS,
+    GOLD_CURRENCY
 }

--- a/app/src/main/java/com/example/runeboundmagic/inventory/ItemSubcategory.kt
+++ b/app/src/main/java/com/example/runeboundmagic/inventory/ItemSubcategory.kt
@@ -1,0 +1,56 @@
+package com.example.runeboundmagic.inventory
+
+/**
+ * Διακριτές υποκατηγορίες ανά βασική κατηγορία.
+ */
+enum class ItemSubcategory(val parent: ItemCategory) {
+    SWORD(ItemCategory.WEAPONS),
+    AXE(ItemCategory.WEAPONS),
+    CROSSBOW(ItemCategory.WEAPONS),
+    ROD(ItemCategory.WEAPONS),
+    DAGGER(ItemCategory.WEAPONS),
+    STAFF(ItemCategory.WEAPONS),
+    BOW(ItemCategory.WEAPONS),
+
+    HELMET(ItemCategory.ARMOR),
+    CHEST(ItemCategory.ARMOR),
+    GLOVES(ItemCategory.ARMOR),
+    BOOTS(ItemCategory.ARMOR),
+    CLOAK(ItemCategory.ARMOR),
+    ROBES(ItemCategory.ARMOR),
+    SHIRT(ItemCategory.ARMOR),
+
+    BUCKLER(ItemCategory.SHIELDS),
+    TOWER(ItemCategory.SHIELDS),
+    MAGIC_BARRIER(ItemCategory.SHIELDS),
+
+    RING(ItemCategory.ACCESSORIES),
+    AMULET(ItemCategory.ACCESSORIES),
+    BELT(ItemCategory.ACCESSORIES),
+    CHARM(ItemCategory.ACCESSORIES),
+
+    POTION_HEALTH(ItemCategory.CONSUMABLES),
+    POTION_MANA(ItemCategory.CONSUMABLES),
+    ELIXIR(ItemCategory.CONSUMABLES),
+    FOOD(ItemCategory.CONSUMABLES),
+
+    SPELL(ItemCategory.SPELLS_SCROLLS),
+    SCROLL(ItemCategory.SPELLS_SCROLLS),
+
+    RUNE(ItemCategory.RUNES_GEMS),
+    GEM(ItemCategory.RUNES_GEMS),
+
+    ORE(ItemCategory.CRAFTING_MATERIALS),
+    HERB(ItemCategory.CRAFTING_MATERIALS),
+    ESSENCE(ItemCategory.CRAFTING_MATERIALS),
+    LEATHER(ItemCategory.CRAFTING_MATERIALS),
+    WOOD(ItemCategory.CRAFTING_MATERIALS),
+
+    KEY(ItemCategory.QUEST_ITEMS),
+    MAP(ItemCategory.QUEST_ITEMS),
+    ARTIFACT(ItemCategory.QUEST_ITEMS),
+
+    GOLD(ItemCategory.GOLD_CURRENCY),
+    TOKEN(ItemCategory.GOLD_CURRENCY),
+    SHARD(ItemCategory.GOLD_CURRENCY);
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,9 @@
     <string name="battle_prep_weapon_element">Στοιχείο: %1$s</string>
     <string name="battle_prep_weapon_speed">Ταχύτητα Επίθεσης: %1$.2f</string>
     <string name="battle_prep_item_category">Κατηγορία: %1$s</string>
+    <string name="battle_prep_item_subcategory">Υποκατηγορία: %1$s</string>
+    <string name="battle_prep_item_stack">Στοίβα: %1$d</string>
+    <string name="battle_prep_empty_slot">Κενή Θέση</string>
     <string name="battle_prep_start_battle">Έναρξη Μάχης</string>
     <string name="close">Κλείσιμο</string>
 </resources>


### PR DESCRIPTION
## Summary
- replace the item model with a strict data class that tracks category, subcategory, stacking, equipment slots, and weapon stats
- add inventory helpers for equipment slots and subcategories and migrate persistence, codex data, and converters to the new schema
- refresh the battle preparation UI to filter items per category, surface per-category capacity counters, and show empty slot placeholders

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e60a2607cc83288b314db85ab86bd9