### PR TITLE
Add missing clip import for BattlePreparationScreen

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext


### PR DESCRIPTION
## Summary
- add the missing androidx.compose.ui.draw.clip import in BattlePreparationScreen to resolve the unresolved reference error

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6152050388328bc64b3d721c74e93