### PR TITLE
Fix icon extension imports and inventory logging

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.runeboundmagic.inventory.icon
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.runeboundmagic.HeroOption
 import com.example.runeboundmagic.R

--- a/app/src/main/java/com/example/runeboundmagic/codex/HeroCodexActivity.kt
+++ b/app/src/main/java/com/example/runeboundmagic/codex/HeroCodexActivity.kt
@@ -63,6 +63,7 @@ import com.example.runeboundmagic.HeroOption
 import com.example.runeboundmagic.R
 import com.example.runeboundmagic.inventory.Item
 import com.example.runeboundmagic.inventory.Rarity
+import com.example.runeboundmagic.inventory.icon
 
 class HeroCodexActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/example/runeboundmagic/codex/HeroProfile.kt
+++ b/app/src/main/java/com/example/runeboundmagic/codex/HeroProfile.kt
@@ -10,6 +10,7 @@ import com.example.runeboundmagic.inventory.Inventory
 import com.example.runeboundmagic.inventory.Item
 import com.example.runeboundmagic.inventory.InventoryItem
 import com.example.runeboundmagic.inventory.WeaponStats
+import com.example.runeboundmagic.inventory.icon
 
 data class HeroProfile(
     val hero: Hero,

--- a/app/src/main/java/com/example/runeboundmagic/inventory/Inventory.kt
+++ b/app/src/main/java/com/example/runeboundmagic/inventory/Inventory.kt
@@ -69,9 +69,10 @@ class Inventory(
             val items = (data["items"] as? List<*>)
                 ?.mapNotNull { element ->
                     (element as? Map<String, Any?>)?.let { itemMap ->
+                        val itemIdValue = itemMap["id"]?.toString().orEmpty()
                         runCatching { Item.fromFirestore(itemMap) }
                             .onFailure { error ->
-                                Log.w(TAG, "Αποτυχία φόρτωσης item ${'$'}{itemMap["id"]}: ${'$'}{error.message}")
+                                Log.w(TAG, "Αποτυχία φόρτωσης item ${'$'}itemIdValue: ${'$'}{error.message}")
                             }
                             .getOrNull()
                     }


### PR DESCRIPTION
## Summary
- import the Item.icon extension where it is used across battle preparation and codex screens
- sanitize inventory loading log message to avoid invalid Kotlin string interpolation

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e615f376b8832899f9ce8f810cc2b9