### PR TITLE
Add scrolling and item imagery to battle prep screen

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -106,7 +108,8 @@ fun BattlePreparationScreen(
             Column(
                 modifier = Modifier
                     .align(Alignment.TopCenter)
-                    .padding(horizontal = 24.dp, vertical = 32.dp),
+                    .padding(horizontal = 24.dp, vertical = 32.dp)
+                    .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(24.dp)
             ) {
                 HeroHeader(
@@ -486,10 +489,12 @@ private fun InventorySlotCell(slot: InventorySlotUiModel, onClick: () -> Unit) {
         contentAlignment = Alignment.Center
     ) {
         if (item != null) {
-            val painter = if (item.icon == "weapon/sword.png") {
-                rememberAssetPainter(item.icon, "weapon/sword_basic.png")
+            val iconPath = item.icon
+            val normalizedIcon = iconPath.removePrefix("assets/")
+            val painter = if (normalizedIcon == "weapon/sword.png") {
+                rememberAssetPainter(iconPath, "weapon/sword.png", "weapon/sword_basic.png")
             } else {
-                rememberAssetPainter(item.icon)
+                rememberAssetPainter(iconPath)
             }
             Image(
                 painter = painter,
@@ -540,7 +545,19 @@ private fun ItemDetailsDialog(item: Item, onDismiss: () -> Unit) {
         },
         title = { Text(text = item.name) },
         text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                val iconPath = item.icon
+                if (iconPath.isNotBlank()) {
+                    Image(
+                        painter = rememberAssetPainter(iconPath),
+                        contentDescription = item.name,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(160.dp)
+                            .clip(RoundedCornerShape(12.dp)),
+                        contentScale = ContentScale.Fit
+                    )
+                }
                 Text(text = item.description)
                 Text(text = stringResource(id = R.string.battle_prep_rarity_label, item.rarity.name))
                 Text(text = stringResource(id = R.string.battle_prep_item_category, item.category.name))

--- a/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationViewModel.kt
+++ b/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationViewModel.kt
@@ -291,7 +291,7 @@ private fun heroClassMetadataFor(heroType: HeroType): HeroClassMetadata = when (
     HeroType.WARRIOR -> HeroClassMetadata(
         id = HeroClass.WARRIOR,
         name = "Warrior",
-        weaponProficiency = "Crossbows",
+        weaponProficiency = "Swords",
         armorProficiency = "Plate Armor"
     )
 

--- a/app/src/main/java/com/example/runeboundmagic/codex/CodexManager.kt
+++ b/app/src/main/java/com/example/runeboundmagic/codex/CodexManager.kt
@@ -136,7 +136,7 @@ private object DefaultEquipmentLoadout {
                 id = "${'$'}prefix_weapon",
                 name = "Ξίφος Τιμής",
                 description = "Ένα αξιόπιστο σπαθί για τους πολεμιστές της πρώτης γραμμής.",
-                icon = "weapon/sword.png",
+                icon = "assets/weapon/sword.png",
                 rarity = Rarity.COMMON,
                 category = ItemCategory.WEAPONS,
                 subcategory = ItemSubcategory.SWORD,

--- a/app/src/main/java/com/example/runeboundmagic/codex/HeroCodexData.kt
+++ b/app/src/main/java/com/example/runeboundmagic/codex/HeroCodexData.kt
@@ -417,7 +417,7 @@ object HeroCodexData {
             id = "warrior_sword",
             name = "Crimson Blade",
             description = "Damage: 48, Element: Fire, Skill: Blazing Rift.",
-            icon = "weapon/sword.png",
+            icon = "assets/weapon/sword.png",
             rarity = Rarity.RARE,
             category = ItemCategory.WEAPONS
         )

--- a/app/src/main/java/com/example/runeboundmagic/ui/AssetPainters.kt
+++ b/app/src/main/java/com/example/runeboundmagic/ui/AssetPainters.kt
@@ -16,6 +16,10 @@ import kotlinx.coroutines.withContext
 fun rememberAssetPainter(assetPath: String, vararg fallbackPaths: String): Painter {
     val context = LocalContext.current
     val fallbackKey = fallbackPaths.contentHashCode()
+    fun sanitize(path: String): String {
+        return path.removePrefix("assets/")
+    }
+
     val painterState = produceState<Painter>(
         initialValue = ColorPainter(Color.Transparent),
         context,
@@ -27,7 +31,7 @@ fun rememberAssetPainter(assetPath: String, vararg fallbackPaths: String): Paint
             fallbackPaths.forEach { path ->
                 if (path.isNotBlank()) add(path)
             }
-        }
+        }.map(::sanitize)
         value = withContext(Dispatchers.IO) {
             candidates.firstNotNullOfOrNull { path ->
                 runCatching {


### PR DESCRIPTION
## Summary
- allow the battle preparation layout to scroll and keep controls reachable
- show inventory item artwork in the details dialog while normalizing sword icons
- point the warrior loadout to the sword asset and let the painter handle optional assets/ prefixes

## Testing
- ./gradlew test *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e62bf8e42c8328bf11428136578bd6