### PR TITLE
Enable battle prep scrolling and show warrior weapon overlay

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/CharacterSelectionActivity.kt
+++ b/app/src/main/java/com/example/runeboundmagic/CharacterSelectionActivity.kt
@@ -8,6 +8,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
+import androidx.core.view.isVisible
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
 
@@ -32,10 +33,22 @@ class CharacterSelectionActivity : AppCompatActivity() {
         confirmButton.setOnClickListener { returnSelection() }
         cancelButton.setOnClickListener { finish() }
 
-        setupHeroCard(R.id.cardWarrior, R.id.heroImageWarrior, R.id.heroLabelWarrior, HeroOption.WARRIOR)
-        setupHeroCard(R.id.cardMage, R.id.heroImageMage, R.id.heroLabelMage, HeroOption.MAGE)
-        setupHeroCard(R.id.cardPriestess, R.id.heroImagePriestess, R.id.heroLabelPriestess, HeroOption.MYSTICAL_PRIESTESS)
-        setupHeroCard(R.id.cardRanger, R.id.heroImageRanger, R.id.heroLabelRanger, HeroOption.RANGER)
+        setupHeroCard(
+            cardId = R.id.cardWarrior,
+            imageId = R.id.heroImageWarrior,
+            labelId = R.id.heroLabelWarrior,
+            weaponId = R.id.heroWeaponWarrior,
+            hero = HeroOption.WARRIOR
+        )
+        setupHeroCard(R.id.cardMage, R.id.heroImageMage, R.id.heroLabelMage, null, HeroOption.MAGE)
+        setupHeroCard(
+            R.id.cardPriestess,
+            R.id.heroImagePriestess,
+            R.id.heroLabelPriestess,
+            null,
+            HeroOption.MYSTICAL_PRIESTESS
+        )
+        setupHeroCard(R.id.cardRanger, R.id.heroImageRanger, R.id.heroLabelRanger, null, HeroOption.RANGER)
 
         selectedHero = savedInstanceState?.getString(KEY_SELECTED_HERO)?.let(HeroOption::fromName)
             ?: intent.getStringExtra(EXTRA_SELECTED_HERO)?.let(HeroOption::fromName)
@@ -53,13 +66,30 @@ class CharacterSelectionActivity : AppCompatActivity() {
         heroBitmaps.clear()
     }
 
-    private fun setupHeroCard(cardId: Int, imageId: Int, labelId: Int, hero: HeroOption) {
+    private fun setupHeroCard(
+        cardId: Int,
+        imageId: Int,
+        labelId: Int,
+        weaponId: Int?,
+        hero: HeroOption
+    ) {
         val card: MaterialCardView = findViewById(cardId)
         val heroImage: ImageView = findViewById(imageId)
         val heroLabel: TextView = findViewById(labelId)
+        val heroWeapon: ImageView? = weaponId?.let { id -> findViewById(id) }
 
         heroImage.setImageBitmap(loadBitmap(hero.assetPath))
         heroLabel.text = getString(hero.displayNameRes)
+
+        heroWeapon?.let { imageView ->
+            val weaponPath = hero.weaponAssetPath
+            if (weaponPath.isNullOrBlank()) {
+                imageView.isVisible = false
+            } else {
+                imageView.setImageBitmap(loadBitmap(weaponPath))
+                imageView.isVisible = true
+            }
+        }
 
         card.setOnClickListener {
             highlightSelection(hero)

--- a/app/src/main/java/com/example/runeboundmagic/HeroOption.kt
+++ b/app/src/main/java/com/example/runeboundmagic/HeroOption.kt
@@ -5,27 +5,32 @@ import androidx.annotation.StringRes
 enum class HeroOption(
     @StringRes val displayNameRes: Int,
     val assetPath: String,
-    @StringRes val descriptionRes: Int
+    @StringRes val descriptionRes: Int,
+    val weaponAssetPath: String? = null
 ) {
     WARRIOR(
         displayNameRes = R.string.hero_warrior,
         assetPath = "characters/warrior.png",
-        descriptionRes = R.string.hero_warrior_desc
+        descriptionRes = R.string.hero_warrior_desc,
+        weaponAssetPath = "assets/weapon/sword.png"
     ),
     MAGE(
         displayNameRes = R.string.hero_mage,
         assetPath = "characters/mage.png",
-        descriptionRes = R.string.hero_mage_desc
+        descriptionRes = R.string.hero_mage_desc,
+        weaponAssetPath = "weapon/rod.png"
     ),
     MYSTICAL_PRIESTESS(
         displayNameRes = R.string.hero_priestess,
         assetPath = "characters/mystical_priestess.png",
-        descriptionRes = R.string.hero_priestess_desc
+        descriptionRes = R.string.hero_priestess_desc,
+        weaponAssetPath = "weapon/rod.png"
     ),
     RANGER(
         displayNameRes = R.string.hero_ranger,
         assetPath = "characters/ranger.png",
-        descriptionRes = R.string.hero_ranger_desc
+        descriptionRes = R.string.hero_ranger_desc,
+        weaponAssetPath = "weapon/crossbow.png"
     );
 
     companion object {

--- a/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -358,13 +359,23 @@ private fun InventoryOverlay(
     onSlotClick: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val scrollState = rememberScrollState()
     Surface(
-        modifier = modifier,
+        modifier = modifier
+            .widthIn(min = 360.dp)
+            .heightIn(max = 520.dp),
         shape = RoundedCornerShape(24.dp),
         tonalElevation = 4.dp,
         color = Color(0xEE111A3A)
     ) {
-        Row(modifier = Modifier.padding(20.dp), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+        Row(
+            modifier = Modifier
+                .padding(20.dp)
+                .fillMaxWidth()
+                .heightIn(max = 480.dp)
+                .verticalScroll(scrollState),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
             CategoryColumn(
                 categories = uiState.categories,
                 selectedCategory = selectedCategory,

--- a/app/src/main/res/layout/activity_character_selection.xml
+++ b/app/src/main/res/layout/activity_character_selection.xml
@@ -52,14 +52,33 @@
                     android:orientation="vertical"
                     android:padding="12dp">
 
-                    <ImageView
-                        android:id="@+id/heroImageWarrior"
+                    <FrameLayout
                         android:layout_width="match_parent"
-                        android:layout_height="@dimen/hero_card_image_height"
-                        android:adjustViewBounds="true"
-                        android:contentDescription="@string/hero_warrior"
-                        android:scaleType="centerCrop"
-                        tools:src="@drawable/ic_launcher_foreground" />
+                        android:layout_height="@dimen/hero_card_image_height">
+
+                        <ImageView
+                            android:id="@+id/heroImageWarrior"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:adjustViewBounds="true"
+                            android:contentDescription="@string/hero_warrior"
+                            android:scaleType="centerCrop"
+                            tools:src="@drawable/ic_launcher_foreground" />
+
+                        <ImageView
+                            android:id="@+id/heroWeaponWarrior"
+                            android:layout_width="56dp"
+                            android:layout_height="56dp"
+                            android:layout_gravity="bottom|end"
+                            android:layout_margin="8dp"
+                            android:adjustViewBounds="true"
+                            android:background="@android:color/transparent"
+                            android:contentDescription="@null"
+                            android:padding="4dp"
+                            android:scaleType="fitCenter"
+                            android:visibility="gone"
+                            tools:src="@drawable/ic_launcher_foreground" />
+                    </FrameLayout>
 
                     <TextView
                         android:id="@+id/heroLabelWarrior"


### PR DESCRIPTION
## Summary
- allow the battle preparation inventory overlay to scroll within a bounded panel
- show the warrior's sword icon on the character selection card via a new weapon asset mapping

## Testing
- ./gradlew :app:assembleDebug *(fails: SDK location not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6339bf88083289ddfe27875aa4086