### PR TITLE
Fix inventory overlay measurement crash

### DIFF
--- a/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationScreen.kt
+++ b/app/src/main/java/com/example/runeboundmagic/battleprep/BattlePreparationScreen.kt
@@ -359,7 +359,6 @@ private fun InventoryOverlay(
     onSlotClick: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val scrollState = rememberScrollState()
     Surface(
         modifier = modifier
             .widthIn(min = 360.dp)
@@ -372,8 +371,7 @@ private fun InventoryOverlay(
             modifier = Modifier
                 .padding(20.dp)
                 .fillMaxWidth()
-                .heightIn(max = 480.dp)
-                .verticalScroll(scrollState),
+                .heightIn(max = 480.dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             CategoryColumn(
@@ -392,7 +390,9 @@ private fun InventoryOverlay(
                     }
                 } ?: uiState.inventorySlots,
                 onSlotClick = onSlotClick,
-                modifier = Modifier.padding(end = 8.dp)
+                modifier = Modifier
+                    .padding(end = 8.dp)
+                    .heightIn(max = 360.dp)
             )
         }
     }


### PR DESCRIPTION
## Summary
- remove the scroll state from the inventory overlay container so the lazy grid is no longer measured with infinite height
- cap the inventory grid height to keep the overlay within its surface bounds

## Testing
- ./gradlew :app:assembleDebug *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e639112a248328a6fcefab605a96c4